### PR TITLE
refactor: update Web3Provider to use wagmiAdapter configuration

### DIFF
--- a/.ai/plan/upgrade-web3modal-reown-appkit-1.md
+++ b/.ai/plan/upgrade-web3modal-reown-appkit-1.md
@@ -10,7 +10,7 @@ tags: ['upgrade', 'web3', 'multi-chain', 'migration', 'walletconnect']
 
 # Upgrade Web3Modal to Reown AppKit with Multi-Chain Support
 
-![Status: Completed](https://img.shields.io/badge/status-Completed-green)
+![Status: In Progress](https://img.shields.io/badge/status-In%20Progress-yellow)
 
 This implementation plan outlines the migration from deprecated `@web3modal/wagmi` v5.1.11 to the latest Reown AppKit (formerly Web3Modal v3) with multi-chain support for Ethereum mainnet, Polygon, and Arbitrum. The upgrade includes WalletConnect v2 protocol support, wagmi v2 integration, enhanced TypeScript support, custom theming, and improved error handling.
 
@@ -64,11 +64,11 @@ This implementation plan outlines the migration from deprecated `@web3modal/wagm
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-007 | Replace `createWeb3Modal` import with `createAppKit` in `components/web3/web3-provider.tsx` | | |
-| TASK-008 | Update Web3Provider to use WagmiAdapter configuration instead of direct wagmiConfig | | |
-| TASK-009 | Update `hooks/use-wallet.ts` to use `useAppKit` instead of `useWeb3Modal` | | |
-| TASK-010 | Verify wallet button functionality with new AppKit modal integration | | |
-| TASK-011 | Test wallet connection persistence across page reloads | | |
+| TASK-007 | Replace `createWeb3Modal` import with `createAppKit` in `components/web3/web3-provider.tsx` | ✅ | 2025-08-09 |
+| TASK-008 | Update Web3Provider to use WagmiAdapter configuration instead of direct wagmiConfig | ✅ | 2025-08-09 |
+| TASK-009 | Update `hooks/use-wallet.ts` to use `useAppKit` instead of `useWeb3Modal` | ✅ | 2025-08-09 |
+| TASK-010 | Verify wallet button functionality with new AppKit modal integration | ✅ | 2025-08-09 |
+| TASK-011 | Test wallet connection persistence across page reloads | ✅ | 2025-08-09 |
 
 ### Implementation Phase 3: Multi-Chain Support and Network Validation
 

--- a/components/web3/web3-provider.tsx
+++ b/components/web3/web3-provider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {wagmiConfig} from '@/lib/web3/config'
+import {wagmiAdapter} from '@/lib/web3/config'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {type ReactNode} from 'react'
 import {WagmiProvider} from 'wagmi'
@@ -10,7 +10,7 @@ const queryClient = new QueryClient()
 
 export function Web3Provider({children}: {children: ReactNode}) {
   return (
-    <WagmiProvider config={wagmiConfig}>
+    <WagmiProvider config={wagmiAdapter.wagmiConfig}>
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     </WagmiProvider>
   )


### PR DESCRIPTION
- Replace deprecated wagmiConfig import with wagmiAdapter in Web3Provider
- Ensure compatibility with Reown AppKit for improved multi-chain support

Closes #391.