### PR TITLE
ci(renovate): add opened, synchronize, reopened PR trigger types

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,7 +6,7 @@ on:
   issues:
     types: [edited]
   pull_request:
-    types: [edited]
+    types: [opened, synchronize, reopened, edited]
   push:
     branches-ignore: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Problem

The `pull_request` trigger in `renovate.yaml` only listed `edited`, so the workflow never ran on normal PR lifecycle events (open, push). This left the `Renovate / Renovate` required status check permanently `pending` for newly opened or updated PRs — blocking merge.

## Fix

Add `opened`, `synchronize`, and `reopened` to the `pull_request` trigger types, matching the standard lifecycle used by the CI/CD Pipeline workflow.