### PR TITLE
chore(ci): port Fro Bot prompt improvements from marcusrbrown/marcusrbrown

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -215,21 +215,22 @@ env:
        - Run `pnpm run validate:web3` to verify Web3 integration patterns.
          Report any validation failures.
        - Scan for stale TODO/FIXME/HACK annotations older than 90 days
-          (use git blame). Collect them into a single issue or update an
-          existing "Stale TODOs" issue.
-        - Workflow health: check the last 7 days of runs for each workflow.
-          Flag any workflow where >50% of expected runs failed, or where
-          scheduled runs produced zero successful auto-generated commits
-          when they should have. (Caught a 1.5-year silent outage in
-          marcusrbrown/marcusrbrown in May 2026; we want it caught fast
-          in this repo too.)
-        - Configuration freshness: flag any pinned contract addresses, RPC
-          endpoint URLs, or chain config entries that haven't been verified
-          against the upstream registry in 90+ days (use git blame). Flag
-          deprecated SDK methods imported but not yet migrated (e.g.,
-          Wagmi/AppKit APIs marked deprecated in release notes). Report
-          findings — do not auto-fix configuration values.
-        - Verify convention compliance:         * No `as any`, `@ts-ignore`, or `@ts-expect-error` in source
+         (use git blame). Collect them into a single issue or update an
+         existing "Stale TODOs" issue.
+       - Workflow health: check the last 7 days of runs for each workflow.
+         Flag any workflow where >50% of expected runs failed, or where
+         scheduled runs produced zero successful auto-generated commits
+         when they should have. (Caught a 1.5-year silent outage in
+         marcusrbrown/marcusrbrown in May 2026; we want it caught fast
+         in this repo too.)
+       - Configuration freshness: flag any pinned contract addresses, RPC
+         endpoint URLs, or chain config entries that haven't been verified
+         against the upstream registry in 90+ days (use git blame). Flag
+         deprecated SDK methods imported but not yet migrated (e.g.,
+         Wagmi/AppKit APIs marked deprecated in release notes). Report
+         findings — do not auto-fix configuration values.
+       - Verify convention compliance:
+         * No `as any`, `@ts-ignore`, or `@ts-expect-error` in source
          * No direct wagmi/AppKit hook usage outside `hooks/` directory
            (components must use `useWallet`, not `useAccount` directly)
          * Imports use `@/` alias for project paths

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -53,6 +53,12 @@ env:
        - React hook dependency arrays and stale closures
        - Functional state updates in useEffect (`setX(prev => ...)` not `setX(x + 1)`)
        - Ref capture at effect execution time for cleanup
+       - Workflow gating (if: conditions, needs: chains, the skipped-needs
+         trap — finalize jobs that depend on conditional prepare jobs MUST
+         use !cancelled() to bypass the implicit success() guard)
+       - Silent failure paths: continue-on-error: true on local deterministic
+         steps is a red flag (use it only for external-API fetches with
+         clear fallback behavior)
 
     2. WEB3 SECURITY (elevated scrutiny)
        - Token approval flows: infinite approvals flagged, amount validation
@@ -209,10 +215,21 @@ env:
        - Run `pnpm run validate:web3` to verify Web3 integration patterns.
          Report any validation failures.
        - Scan for stale TODO/FIXME/HACK annotations older than 90 days
-         (use git blame). Collect them into a single issue or update an
-         existing "Stale TODOs" issue.
-       - Verify convention compliance:
-         * No `as any`, `@ts-ignore`, or `@ts-expect-error` in source
+          (use git blame). Collect them into a single issue or update an
+          existing "Stale TODOs" issue.
+        - Workflow health: check the last 7 days of runs for each workflow.
+          Flag any workflow where >50% of expected runs failed, or where
+          scheduled runs produced zero successful auto-generated commits
+          when they should have. (Caught a 1.5-year silent outage in
+          marcusrbrown/marcusrbrown in May 2026; we want it caught fast
+          in this repo too.)
+        - Configuration freshness: flag any pinned contract addresses, RPC
+          endpoint URLs, or chain config entries that haven't been verified
+          against the upstream registry in 90+ days (use git blame). Flag
+          deprecated SDK methods imported but not yet migrated (e.g.,
+          Wagmi/AppKit APIs marked deprecated in release notes). Report
+          findings — do not auto-fix configuration values.
+        - Verify convention compliance:         * No `as any`, `@ts-ignore`, or `@ts-expect-error` in source
          * No direct wagmi/AppKit hook usage outside `hooks/` directory
            (components must use `useWallet`, not `useAccount` directly)
          * Imports use `@/` alias for project paths
@@ -392,6 +409,9 @@ env:
       a failing PR (then ONLY post the fix-summary comment on that PR).
 
     Hard boundaries:
+    - Never edit Marcus's first-person content (README intro, blog posts,
+      marketing copy, any user-facing language). Report stale claims;
+      don't rewrite them.
     - Never force-push, rewrite history, or delete branches.
     - Never push directly to the default branch. Direct pushes are allowed
       only to an existing non-default PR branch you are repairing under


### PR DESCRIPTION
## Summary

Ports 5 prompt enhancements into tokentoilet's `.github/workflows/fro-bot.yaml`, developed during a 2026-05-23 session that fixed a **1.5-year silent automation outage** in `marcusrbrown/marcusrbrown` caused by GitHub Actions' implicit `success()` gate on `needs:` chains (the skipped-needs trap).

See marcusrbrown/marcusrbrown#923 for the originating bug and marcusrbrown/marcusrbrown#924 for the source Fro Bot workflow changes.

All additions are surgical inserts — no structural changes, no section renumbering, no voice changes. The existing Web3/DeFi organization is preserved.

---

## Changes

### PR_REVIEW_PROMPT — 2 new sub-bullets in section 1 (CORRECTNESS & EDGE CASES)

**#1 — Skipped-needs trap detection**

Flags finalize jobs that depend on conditional prepare jobs and don't use `!cancelled()` to bypass the implicit `success()` guard.

**#2 — `continue-on-error` red-flag**

Flags `continue-on-error: true` on local deterministic steps as a red flag (only acceptable on external-API fetches with clear fallback behavior).

Both folded naturally into the existing CORRECTNESS section rather than creating a new section, since tokentoilet doesn't have a separate AUTOMATION INTEGRITY section like mrbro.dev does.

---

### SCHEDULE_PROMPT — 3 additions

**#3 — Workflow-health monitor** (new bullet in category 3 CODE QUALITY & REPO HYGIENE)

Flags workflows where >50% of expected runs failed or scheduled runs produced zero successful commits when they should have. Directly motivated by the 1.5-year silent outage.

**#4 — Configuration freshness scan** (Web3-adapted, new bullet in category 3)

Instead of the mrbro.dev version (which scans README copy for stale date claims), this scans for:
- Pinned contract addresses / RPC endpoint URLs not verified against upstream registry in 90+ days
- Deprecated Wagmi/AppKit SDK methods imported but not yet migrated

Not redundant with the existing category 2 Web3 security checks (those look for secrets in source; this looks for stale/deprecated config values).

**#5 — Never edit first-person voice** (new bullet in Hard boundaries)

Adapted from mrbro.dev's equivalent boundary. Tells the bot to report stale claims in user-facing copy rather than rewriting them.

---

## Verification

- `actionlint .github/workflows/fro-bot.yaml` — clean (no output)
- Line count: 554 (was 534, +20 net)
- All 5 improvements applied; none dropped
