### PR TITLE
ci(fro-bot): skip ce:review skill in per-PR review prompt

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -45,6 +45,12 @@ env:
     + Reown AppKit + Tailwind CSS v4 + Vitest + Storybook, deployed to Vercel.
     Read AGENTS.md for full project conventions before reviewing.
 
+    Do the review directly yourself using the rubric below. Do NOT invoke
+    the `ce:review` skill or any other multi-agent Systematic review
+    workflow — they spawn parallel persona subagents that are too slow and
+    too costly for per-PR CI. A single-pass review against this rubric is
+    the required approach here.
+
     Focus your review on:
 
     1. CORRECTNESS & EDGE CASES


### PR DESCRIPTION
## Why

The per-PR Fro Bot review job runs under the project's OpenCode config, whose Systematic plugin auto-invokes the `ce:review` skill whenever it detects a review task. That skill spawns multiple parallel persona subagents — useful for deep pre-merge review, but too slow and costly for every PR CI run (recent review jobs took 7+ minutes).

## What

Instruct `PR_REVIEW_PROMPT` to do a single-pass review directly against the existing inline rubric and to **not** invoke `ce:review` or any other multi-agent Systematic review workflow.

The inline rubric (correctness, Web3 security, architecture, type safety, styling, testing, breaking changes) and the required output structure are unchanged — only the execution method is constrained to a single pass.

No behavior change to scheduled autohealing or workflow-dispatch prompts.