### PR TITLE
docs: archive pre-Systematic .ai/ planning tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,19 +46,6 @@ legacy.md
 .specstory/.what-is-this.md
 
 # AI-related files
-# Ignore the entire .ai directory but keep specific subdirectories
-!.ai/
-.ai/*
-!.ai/analysis/
-!.ai/analysis/*
-!.ai/docs/
-!.ai/docs/*
-!.ai/metrics/
-!.ai/metrics/*
-!.ai/notes/
-!.ai/notes/*
-!.ai/plan/
-!.ai/plan/*
 
 # Storybook static build output
 /storybook-static

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,4 @@
 globs:
-  - '!.ai/**'
   - '!AGENTS.md'
   - '!docs/brainstorms/**'
   - '!docs/plans/**'

--- a/docs/archive/legacy-planning/notes/feature-prompts.md
+++ b/docs/archive/legacy-planning/notes/feature-prompts.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 # Feature Prompts
 
 This document collects prompts that can be used with AI assistants to generate implementation plans using the [/create-implementation-plan](https://github.com/PlagueHO/awesome-copilot/blob/9fe63b3aed16abc391fe7d2b957e0d4bf3517ce8/prompts/create-implementation-plan.prompt.md) prompt in Copilot Chat.

--- a/docs/archive/legacy-planning/plan/bug-tailwind-css-rendering-1.md
+++ b/docs/archive/legacy-planning/plan/bug-tailwind-css-rendering-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Fix critical Tailwind CSS v4 rendering issues causing completely unstyled website
 version: 1.0

--- a/docs/archive/legacy-planning/plan/design-system-comprehensive-1.md
+++ b/docs/archive/legacy-planning/plan/design-system-comprehensive-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Create Comprehensive Design System for Token Toilet Web3 DeFi Application
 version: 1.0

--- a/docs/archive/legacy-planning/plan/feature-dynamic-wallet-loading-1.md
+++ b/docs/archive/legacy-planning/plan/feature-dynamic-wallet-loading-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Implement Module-Level Dynamic Imports for Bundle Optimization
 version: 2.7

--- a/docs/archive/legacy-planning/plan/feature-phase1-setup-wallet-integration-1.md
+++ b/docs/archive/legacy-planning/plan/feature-phase1-setup-wallet-integration-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Phase 1 Setup and Wallet Integration - Foundation Implementation
 version: 1.0

--- a/docs/archive/legacy-planning/plan/refactor-fast-refresh-exports-1.md
+++ b/docs/archive/legacy-planning/plan/refactor-fast-refresh-exports-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Refactor Component Exports for Fast Refresh Compliance
 version: 1.0

--- a/docs/archive/legacy-planning/plan/refactor-react-hooks-patterns-1.md
+++ b/docs/archive/legacy-planning/plan/refactor-react-hooks-patterns-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Enhance React Hooks Best Practices Compliance
 version: 1.0

--- a/docs/archive/legacy-planning/plan/upgrade-tailwind-v4-1.md
+++ b/docs/archive/legacy-planning/plan/upgrade-tailwind-v4-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Migrate Token Toilet from Tailwind CSS v3 to v4 using CSS-first configuration approach
 version: 1.0

--- a/docs/archive/legacy-planning/plan/upgrade-web3modal-reown-appkit-1.md
+++ b/docs/archive/legacy-planning/plan/upgrade-web3modal-reown-appkit-1.md
@@ -1,3 +1,5 @@
+> **⚠️ ARCHIVED — Pre-Systematic legacy planning.** This document predates the Systematic workflow process and the MVP rebaseline. It is retained for historical reference only and does not reflect current project scope or conventions. For current scope, see [`docs/brainstorms/2026-04-16-mvp-rebaseline-requirements.md`](../../../brainstorms/2026-04-16-mvp-rebaseline-requirements.md).
+
 ---
 goal: Upgrade Web3Modal to Reown AppKit with Multi-Chain Support
 version: 1.0

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -711,8 +711,6 @@ it('shows loading skeleton while component loads', async () => {
 
 **Expected Impact:** 50-100 KB bundle reduction when dynamic components are integrated into feature pages.
 
-See `.ai/metrics/performance-validation-2025-10-11.md` for detailed performance validation results.
-
 ## Best Practices Summary
 
 ### Development Guidelines

--- a/docs/performance/dynamic-loading-summary.md
+++ b/docs/performance/dynamic-loading-summary.md
@@ -193,6 +193,3 @@ The dynamic loading infrastructure is **production-ready and awaiting integratio
 
 No additional implementation work is required - the infrastructure handles all complexity of dynamic loading, error handling, and loading states transparently.
 
----
-
-**For detailed validation results, see:** `.ai/metrics/performance-validation-2025-10-11.md`

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,7 +8,6 @@ export default defineConfig(
       '.github/prompts',
       'AGENTS.md',
       'llms.txt',
-      '.ai/',
       'docs/**/*.md',
       'CONTRIBUTING.md',
       'CHANGELOG.md',


### PR DESCRIPTION
Consolidates the last of the legacy planning docs under `docs/archive/`, completing the documentation reconciliation begun in #1169.

## What

The `.ai/` tree held pre-Systematic working plans and notes (last touched April 2026), predating both the Systematic workflow and the MVP rebaseline.

- Moved `.ai/plan/` (8 files) and `.ai/notes/` (1 file) to `docs/archive/legacy-planning/` with archive banners pointing at the canonical rebaseline scope doc.
- Collapsed the now-dead `.ai/` allowlist block in `.gitignore`.
- Dropped the stale `.ai/` ignore entries from `eslint.config.ts` and `.markdownlint-cli2.yaml`.
- Removed two references to `.ai/metrics/performance-validation-2025-10-11.md` in `architecture.md` and `dynamic-loading-summary.md` — that file was never committed, so the references were already dangling.

## Notes

Docs/config only — no application code. File moves use `git mv` to preserve history. `pnpm lint` passes; no live `.ai/` references remain.