### PR TITLE
fix(privacy): default analytics telemetry to opt-in (off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,8 +35,9 @@ NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
 # Optional Feature Flags
 # =============================================================================
 
-# Enable analytics tracking (default: true)
-# NEXT_PUBLIC_ENABLE_ANALYTICS=true
+# Enable Reown AppKit analytics (opt-in, default: false)
+# Telemetry is off unless explicitly enabled. Only set to true with informed consent.
+# NEXT_PUBLIC_ENABLE_ANALYTICS=false
 
 # Enable testnet support for development (default: false)
 # NEXT_PUBLIC_ENABLE_TESTNETS=false

--- a/docs/development/environment-setup.md
+++ b/docs/development/environment-setup.md
@@ -56,8 +56,8 @@ By default, the application uses public RPC endpoints. You can override these fo
 
 #### `NEXT_PUBLIC_ENABLE_ANALYTICS`
 - **Type**: Boolean string ("true" or "false")
-- **Default**: "true"
-- **Description**: Enables analytics tracking through WalletConnect
+- **Default**: "false"
+- **Description**: Opt-in Reown AppKit analytics. Off unless explicitly enabled with informed user consent.
 
 #### `NEXT_PUBLIC_ENABLE_TESTNETS`
 - **Type**: Boolean string ("true" or "false")
@@ -127,7 +127,7 @@ Set environment variables in the Vercel dashboard:
 - [ ] `NEXT_PUBLIC_APP_URL` set to production domain
 - [ ] `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` configured
 - [ ] Custom RPC endpoints configured (recommended)
-- [ ] Analytics enabled (`NEXT_PUBLIC_ENABLE_ANALYTICS=true`)
+- [ ] Analytics left off unless opt-in consent is in place (`NEXT_PUBLIC_ENABLE_ANALYTICS` defaults to `false`)
 - [ ] Testnets disabled (`NEXT_PUBLIC_ENABLE_TESTNETS=false`)
 
 ## Troubleshooting

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -274,7 +274,8 @@ NEXT_PUBLIC_ENABLE_DEBUG_MODE=true
 ```dotenv
 NEXT_PUBLIC_APP_URL=https://tokentoilet.com
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=production_project_id
-NEXT_PUBLIC_ENABLE_ANALYTICS=true
+# Analytics is opt-in and off by default. Only enable with informed user consent:
+# NEXT_PUBLIC_ENABLE_ANALYTICS=true
 ```
 
 ## Deployment

--- a/env.ts
+++ b/env.ts
@@ -30,7 +30,7 @@ export const schemas = {
       .string()
       .transform(val => val === 'true')
       .pipe(z.boolean())
-      .default(true),
+      .default(false),
     NEXT_PUBLIC_ENABLE_TESTNETS: z
       .string()
       .transform(val => val === 'true')


### PR DESCRIPTION
## Problem

`NEXT_PUBLIC_ENABLE_ANALYTICS` defaulted to `true` in `env.ts`, and that value is passed straight into Reown AppKit's `features.analytics` (`lib/web3/config.ts`). Any deployment without an explicit `NEXT_PUBLIC_ENABLE_ANALYTICS=false` override therefore sends wallet-interaction telemetry off-device **without user consent** — a violation of the opt-in-only telemetry requirement.

## Fix

- `env.ts`: default `NEXT_PUBLIC_ENABLE_ANALYTICS` to `false`. Telemetry is now off unless explicitly enabled.
- `.env.example`: document it as opt-in, off by default, only enabled with informed consent.

## ⚠️ Operational follow-up (not in this PR)

This code change sets the safe default, but the **Vercel production environment** must be checked: if `NEXT_PUBLIC_ENABLE_ANALYTICS` is explicitly set to `true` there, this default is overridden and telemetry stays on until that env var is removed or set to `false` (and the app redeployed). Verify the production and preview env values.

## Verification

- `pnpm type-check` — clean
- `pnpm lint` — 0 errors

No application logic changed beyond the default value.