### PR TITLE
feat(disposal): simulate transfers before prompting signature

### DIFF
--- a/components/web3/disposal-flow.test.tsx
+++ b/components/web3/disposal-flow.test.tsx
@@ -115,10 +115,14 @@ describe('DisposalFlow', () => {
       refresh: vi.fn(),
     } as unknown as ReturnType<typeof useUnwantedTokens>)
 
+    // Default: simulation succeeded, canDispose=true, not simulating
     vi.mocked(useTokenDisposal).mockReturnValue({
       dispose: mockDispose,
       isPending: false,
       isSuccess: false,
+      isSimulating: false,
+      canDispose: true,
+      isSimulationEnabled: true,
       error: null,
       txHash: undefined,
     })
@@ -197,6 +201,9 @@ describe('DisposalFlow', () => {
         }),
         isPending: false,
         isSuccess: false,
+        isSimulating: false,
+        canDispose: true,
+        isSimulationEnabled: true,
         error: null,
         txHash: undefined,
       } as unknown as ReturnType<typeof useTokenDisposal>
@@ -210,5 +217,108 @@ describe('DisposalFlow', () => {
     // when: first token disposal starts
     // then: dispose is called with first token
     expect(disposeCallTokens).toContain('TKN1')
+  })
+
+  describe('DisposalExecutor simulation states', () => {
+    it('renders "Checking transfer safety..." while simulation is in progress', async () => {
+      // Given simulation is loading
+      vi.mocked(useTokenDisposal).mockReturnValue({
+        dispose: mockDispose,
+        isPending: false,
+        isSuccess: false,
+        isSimulating: true,
+        canDispose: false,
+        isSimulationEnabled: true,
+        error: null,
+        txHash: undefined,
+      })
+
+      render(<DisposalFlow />)
+      await userEvent.click(screen.getByTestId('mock-select-token-1'))
+      await userEvent.click(screen.getByRole('button', {name: /continue/i}))
+      await userEvent.click(screen.getByRole('button', {name: /confirm burn/i}))
+
+      // Then the simulating status is shown
+      expect(screen.getByText(/checking transfer safety/i)).toBeInTheDocument()
+    })
+
+    it('calls onComplete with success:false when simulation fails; does NOT reach write', async () => {
+      // Given simulation failed
+      const simulationError = new Error('Transfer would revert')
+      vi.mocked(useTokenDisposal).mockReturnValue({
+        dispose: mockDispose,
+        isPending: false,
+        isSuccess: false,
+        isSimulating: false,
+        canDispose: false,
+        isSimulationEnabled: true,
+        error: simulationError,
+        txHash: undefined,
+      })
+
+      render(<DisposalFlow />)
+      await userEvent.click(screen.getByTestId('mock-select-token-1'))
+      await userEvent.click(screen.getByRole('button', {name: /continue/i}))
+      await userEvent.click(screen.getByRole('button', {name: /confirm burn/i}))
+
+      // Then the error is shown and dispose is not called for a write
+      expect(screen.getByText(/transfer would revert/i)).toBeInTheDocument()
+      // dispose() is called once (to hit guards), but since error is already set, no write occurs
+      expect(mockDispose).not.toHaveBeenCalled()
+    })
+
+    it('triggers dispose once when simulation succeeds (canDispose=true)', async () => {
+      // Given simulation succeeded
+      vi.mocked(useTokenDisposal).mockReturnValue({
+        dispose: mockDispose,
+        isPending: false,
+        isSuccess: false,
+        isSimulating: false,
+        canDispose: true,
+        isSimulationEnabled: true,
+        error: null,
+        txHash: undefined,
+      })
+
+      render(<DisposalFlow />)
+      await userEvent.click(screen.getByTestId('mock-select-token-1'))
+      await userEvent.click(screen.getByRole('button', {name: /continue/i}))
+      await userEvent.click(screen.getByRole('button', {name: /confirm burn/i}))
+
+      // Then dispose is called exactly once
+      expect(mockDispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows "Waiting for wallet confirmation..." while write is pending', async () => {
+      // Given write is pending
+      vi.mocked(useTokenDisposal).mockReturnValue({
+        dispose: mockDispose,
+        isPending: true,
+        isSuccess: false,
+        isSimulating: false,
+        canDispose: false,
+        isSimulationEnabled: true,
+        error: null,
+        txHash: undefined,
+      })
+
+      render(<DisposalFlow />)
+      await userEvent.click(screen.getByTestId('mock-select-token-1'))
+      await userEvent.click(screen.getByRole('button', {name: /continue/i}))
+      await userEvent.click(screen.getByRole('button', {name: /confirm burn/i}))
+
+      // Then the writing status is shown
+      expect(screen.getByText(/waiting for wallet confirmation/i)).toBeInTheDocument()
+    })
+
+    it('shows updated dispose-step helper copy about preflight checks', async () => {
+      render(<DisposalFlow />)
+      await userEvent.click(screen.getByTestId('mock-select-token-1'))
+      await userEvent.click(screen.getByRole('button', {name: /continue/i}))
+      await userEvent.click(screen.getByRole('button', {name: /confirm burn/i}))
+
+      // Then the updated copy is shown
+      expect(screen.getByText(/each token is checked before your wallet is prompted/i)).toBeInTheDocument()
+    })
   })
 })

--- a/components/web3/disposal-flow.test.tsx
+++ b/components/web3/disposal-flow.test.tsx
@@ -242,8 +242,8 @@ describe('DisposalFlow', () => {
       expect(screen.getByText(/checking transfer safety/i)).toBeInTheDocument()
     })
 
-    it('calls onComplete with success:false when simulation fails; does NOT reach write', async () => {
-      // Given simulation failed
+    it('advances to results with a failed token when simulation fails; never writes', async () => {
+      // Given a single selected token whose preflight simulation has failed
       const simulationError = new Error('Transfer would revert')
       vi.mocked(useTokenDisposal).mockReturnValue({
         dispose: mockDispose,
@@ -261,9 +261,11 @@ describe('DisposalFlow', () => {
       await userEvent.click(screen.getByRole('button', {name: /continue/i}))
       await userEvent.click(screen.getByRole('button', {name: /confirm burn/i}))
 
-      // Then the error is shown and dispose is not called for a write
-      expect(screen.getByText(/transfer would revert/i)).toBeInTheDocument()
-      // dispose() is called once (to hit guards), but since error is already set, no write occurs
+      // Then the flow does NOT deadlock: it reports completion and advances to
+      // the results screen showing the token as failed ("Failed checks will be skipped").
+      expect(await screen.findByText(/results/i)).toBeInTheDocument()
+      expect(screen.getByText(/1 failed/i)).toBeInTheDocument()
+      // And a doomed transfer is never written (no blind signature prompt).
       expect(mockDispose).not.toHaveBeenCalled()
     })
 

--- a/components/web3/disposal-flow.tsx
+++ b/components/web3/disposal-flow.tsx
@@ -35,17 +35,21 @@ function DisposalExecutor({
   token: CategorizedToken
   onComplete: (result: DisposalResult) => void
 }) {
-  const {dispose, isPending, isSuccess, error} = useTokenDisposal(token)
+  const {dispose, isPending, isSuccess, isSimulating, canDispose, isSimulationEnabled, error} = useTokenDisposal(token)
   const hasTriggeredRef = useRef(false)
   const hasReportedRef = useRef(false)
 
   useEffect(() => {
-    if (!hasTriggeredRef.current) {
+    if (hasTriggeredRef.current || hasReportedRef.current) return
+    if (error != null || isSuccess || isPending || isSimulating) return
+    // Normal path: simulation produced a safe request (canDispose).
+    // Guard/invalid path: simulation disabled — call dispose() once to hit the hook's guards.
+    if (canDispose || !isSimulationEnabled) {
       hasTriggeredRef.current = true
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       dispose()
     }
-  }, [dispose])
+  }, [canDispose, dispose, error, isPending, isSimulating, isSuccess, isSimulationEnabled])
 
   useEffect(() => {
     if (hasTriggeredRef.current && !hasReportedRef.current && (isSuccess || error != null)) {
@@ -60,15 +64,21 @@ function DisposalExecutor({
     }
   }, [isSuccess, error, token.address, token.name, token.symbol, onComplete])
 
+  const status =
+    error == null ? (isSuccess ? 'success' : isPending ? 'writing' : isSimulating ? 'simulating' : 'queued') : 'failed'
+
   return (
     <Card className="p-4">
       <div className="flex items-center gap-3 mb-2">
-        {isPending && <Clock className="h-5 w-5 text-yellow-500 animate-spin" />}
-        {isSuccess && <CheckCircle className="h-5 w-5 text-green-500" />}
-        {error != null && <AlertCircle className="h-5 w-5 text-red-500" />}
-        {!isPending && !isSuccess && error == null && <Clock className="h-5 w-5 text-gray-400" />}
+        {status === 'simulating' && <Clock className="h-5 w-5 text-blue-500 animate-spin" />}
+        {status === 'writing' && <Clock className="h-5 w-5 text-yellow-500 animate-spin" />}
+        {status === 'success' && <CheckCircle className="h-5 w-5 text-green-500" />}
+        {status === 'failed' && <AlertCircle className="h-5 w-5 text-red-500" />}
+        {status === 'queued' && <Clock className="h-5 w-5 text-gray-400" />}
         <span className="font-medium">{token.name}</span>
       </div>
+      {status === 'simulating' && <p className="text-sm text-blue-500 ml-8">Checking transfer safety...</p>}
+      {status === 'writing' && <p className="text-sm text-yellow-500 ml-8">Waiting for wallet confirmation...</p>}
       {error != null && <p className="text-sm text-red-500 ml-8">{error.message}</p>}
     </Card>
   )
@@ -181,7 +191,9 @@ export function DisposalFlow() {
           <h2 className="text-xl font-bold">
             Disposing {currentIndex + 1} of {selectedTokens.length}...
           </h2>
-          <p className="text-gray-500 text-sm mt-1">Please confirm the transactions in your wallet.</p>
+          <p className="text-gray-500 text-sm mt-1">
+            Each token is checked before your wallet is prompted. Failed checks will be skipped.
+          </p>
         </div>
 
         <DisposalExecutor key={tokenToDispose.address} token={tokenToDispose} onComplete={handleDisposalComplete} />

--- a/components/web3/disposal-flow.tsx
+++ b/components/web3/disposal-flow.tsx
@@ -52,7 +52,10 @@ function DisposalExecutor({
   }, [canDispose, dispose, error, isPending, isSimulating, isSuccess, isSimulationEnabled])
 
   useEffect(() => {
-    if (hasTriggeredRef.current && !hasReportedRef.current && (isSuccess || error != null)) {
+    // Report any terminal outcome (success or error), even when no write was
+    // triggered — a failed preflight is a terminal result that must advance the
+    // batch, otherwise a reverting token deadlocks the disposal flow.
+    if (!hasReportedRef.current && (isSuccess || error != null)) {
       hasReportedRef.current = true
       onComplete({
         address: token.address,

--- a/hooks/use-token-disposal.test.ts
+++ b/hooks/use-token-disposal.test.ts
@@ -3,7 +3,7 @@ import {act, renderHook, waitFor} from '@testing-library/react'
 import toast from 'react-hot-toast'
 import {erc20Abi} from 'viem'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {useAccount, useChainId, useWriteContract} from 'wagmi'
+import {useAccount, useChainId, useSimulateContract, useWriteContract} from 'wagmi'
 import type {CategorizedToken} from '@/lib/web3/token-filtering'
 import {TokenCategory, TokenValueClass} from '@/lib/web3/token-filtering'
 import {TokenRiskScore} from '@/lib/web3/token-metadata'
@@ -16,6 +16,7 @@ vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
   useChainId: vi.fn(),
   useWriteContract: vi.fn(),
+  useSimulateContract: vi.fn(),
 }))
 
 vi.mock('./use-wallet', () => ({
@@ -65,6 +66,15 @@ describe('useTokenDisposal', () => {
     },
   }
 
+  const mockSimulationRequest = {
+    address: mockTokenAddress,
+    abi: erc20Abi,
+    functionName: 'transfer' as const,
+    args: [BURN_ADDRESS, mockToken.balance] as const,
+    account: mockUserAddress,
+    chainId: 11155111,
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -91,117 +101,442 @@ describe('useTokenDisposal', () => {
       error: null,
       data: undefined,
     } as never)
+
+    // Default: successful simulation
+    vi.mocked(useSimulateContract).mockReturnValue({
+      data: {request: mockSimulationRequest},
+      error: null,
+      isLoading: false,
+      isFetching: false,
+    } as never)
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('calls transfer with the burn address and token balance', async () => {
-    const mockWriteContract = vi.fn()
-    vi.mocked(useWriteContract).mockReturnValue({
-      writeContract: mockWriteContract,
-      isPending: false,
-      isSuccess: false,
-      error: null,
-      data: undefined,
-    } as never)
+  describe('simulation configuration', () => {
+    it('configures useSimulateContract with correct args when wallet is connected and token is valid', () => {
+      // Given a connected wallet with a valid token
+      renderHook(() => useTokenDisposal(mockToken))
 
-    const {result} = renderHook(() => useTokenDisposal(mockToken))
+      // When the hook initializes
+      // Then useSimulateContract is called with the correct transfer parameters
+      expect(useSimulateContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: mockTokenAddress,
+          abi: erc20Abi,
+          functionName: 'transfer',
+          args: [BURN_ADDRESS, mockToken.balance],
+          account: mockUserAddress,
+          chainId: 11155111,
+          query: expect.objectContaining({
+            enabled: true,
+            retry: false,
+          }) as unknown,
+        }),
+      )
+    })
 
-    // Given a connected wallet and a token selected for disposal
-    // When dispose is executed
-    await result.current.dispose()
+    it('disables simulation when wallet is disconnected', () => {
+      // Given a disconnected wallet
+      vi.mocked(useWallet).mockReturnValue({
+        isConnected: false,
+        getUnsupportedNetworkError: vi.fn(() => null),
+      } as never)
+      vi.mocked(useAccount).mockReturnValue({address: undefined} as never)
 
-    // Then the hook writes an ERC-20 transfer to the burn address
-    expect(mockWriteContract).toHaveBeenCalledWith({
-      address: mockTokenAddress,
-      abi: erc20Abi,
-      functionName: 'transfer',
-      args: [BURN_ADDRESS, mockToken.balance],
-      chainId: 11155111,
+      renderHook(() => useTokenDisposal(mockToken))
+
+      // Then simulation is disabled
+      expect(useSimulateContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({enabled: false}) as unknown,
+        }),
+      )
+    })
+
+    it('disables simulation on unsupported network', () => {
+      // Given an unsupported network
+      const networkError = {error: {userFriendlyMessage: 'Unsupported network'}}
+      vi.mocked(useWallet).mockReturnValue({
+        isConnected: true,
+        getUnsupportedNetworkError: vi.fn(() => networkError),
+      } as never)
+
+      renderHook(() => useTokenDisposal(mockToken))
+
+      // Then simulation is disabled
+      expect(useSimulateContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({enabled: false}) as unknown,
+        }),
+      )
+    })
+
+    it('disables simulation for zero address (dummy token)', () => {
+      // Given a dummy token with zero address
+      const dummyToken: CategorizedToken = {
+        ...mockToken,
+        address: '0x0000000000000000000000000000000000000000',
+      }
+
+      renderHook(() => useTokenDisposal(dummyToken))
+
+      // Then simulation is disabled
+      expect(useSimulateContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({enabled: false}) as unknown,
+        }),
+      )
+    })
+
+    it('disables simulation when token balance is zero', () => {
+      // Given a token with zero balance
+      const zeroBalanceToken: CategorizedToken = {
+        ...mockToken,
+        balance: BigInt(0),
+      }
+
+      renderHook(() => useTokenDisposal(zeroBalanceToken))
+
+      // Then simulation is disabled
+      expect(useSimulateContract).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({enabled: false}) as unknown,
+        }),
+      )
     })
   })
 
-  it('adds the disposal transaction to the queue on success', () => {
-    const mockAddTransaction = vi.fn()
-    vi.mocked(useTransactionQueue).mockReturnValue({
-      addTransaction: mockAddTransaction,
-    } as never)
+  describe('dispose() behavior', () => {
+    it('calls writeContract with the simulated request (not a hand-built object)', async () => {
+      // Given a successful simulation
+      const mockWriteContract = vi.fn()
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: mockWriteContract,
+        isPending: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
 
-    renderHook(() => useTokenDisposal(mockToken))
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
 
-    const mutationConfig = vi.mocked(useWriteContract).mock.calls[0]?.[0]?.mutation
-    const hash = '0xabc123' as Address
+      // When dispose is called
+      await result.current.dispose()
 
-    // Given a submitted disposal transaction
-    // When wagmi reports a successful submission
-    mutationConfig?.onSuccess?.(hash, {} as never, {}, {} as never)
+      // Then writeContract receives the exact simulated request object (not a hand-built one)
+      expect(mockWriteContract).toHaveBeenCalledWith(mockSimulationRequest)
+      // Verify it was called with the exact reference from simulateData.request
+      expect(mockWriteContract).toHaveBeenCalledTimes(1)
+    })
 
-    // Then the transaction is queued for receipt monitoring
-    expect(mockAddTransaction).toHaveBeenCalledWith({
-      hash,
-      chainId: 11155111,
-      type: 'dispose',
-      title: 'Dispose USDC',
-      description: 'Burn 1000 USDC',
-      value: mockToken.balance,
-      to: BURN_ADDRESS,
-      from: mockUserAddress,
+    it('does NOT write when simulation is still loading', async () => {
+      // Given simulation is in progress
+      const mockWriteContract = vi.fn()
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: mockWriteContract,
+        isPending: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
+      vi.mocked(useSimulateContract).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: true,
+        isFetching: true,
+      } as never)
+
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
+
+      // When dispose is called while simulation is loading
+      await result.current.dispose()
+
+      // Then no write is attempted
+      expect(mockWriteContract).not.toHaveBeenCalled()
+      expect(result.current.isSimulating).toBe(true)
+      expect(result.current.canDispose).toBe(false)
+    })
+
+    it('does NOT write when simulation fails; exposes simulation error', async () => {
+      // Given a failed simulation
+      const simulationError = new Error('Transfer would revert: insufficient balance')
+      const mockWriteContract = vi.fn()
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: mockWriteContract,
+        isPending: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
+      vi.mocked(useSimulateContract).mockReturnValue({
+        data: undefined,
+        error: simulationError,
+        isLoading: false,
+        isFetching: false,
+      } as never)
+
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
+
+      // When dispose is called after simulation failure
+      await result.current.dispose()
+
+      // Then no write is attempted and error is exposed
+      expect(mockWriteContract).not.toHaveBeenCalled()
+      expect(result.current.error).toBe(simulationError)
+      expect(result.current.canDispose).toBe(false)
+    })
+
+    it('sets wallet error and does NOT write when wallet is disconnected', async () => {
+      // Given a disconnected wallet
+      vi.mocked(useWallet).mockReturnValue({
+        isConnected: false,
+        getUnsupportedNetworkError: vi.fn(() => null),
+      } as never)
+      vi.mocked(useAccount).mockReturnValue({address: undefined} as never)
+      vi.mocked(useSimulateContract).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: false,
+        isFetching: false,
+      } as never)
+
+      const mockWriteContract = vi.fn()
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: mockWriteContract,
+        isPending: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
+
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
+
+      // When dispose is called
+      await result.current.dispose()
+
+      // Then error is set and no write occurs
+      expect(mockWriteContract).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(result.current.error?.message).toBe('Wallet connection required to dispose tokens')
+      })
+    })
+
+    it('sets network error and does NOT write on unsupported network', async () => {
+      // Given an unsupported network
+      const networkError = {error: {userFriendlyMessage: 'Please switch to Sepolia'}}
+      vi.mocked(useWallet).mockReturnValue({
+        isConnected: true,
+        getUnsupportedNetworkError: vi.fn(() => networkError),
+      } as never)
+      vi.mocked(useSimulateContract).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: false,
+        isFetching: false,
+      } as never)
+
+      const mockWriteContract = vi.fn()
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: mockWriteContract,
+        isPending: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
+
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
+
+      // When dispose is called
+      await result.current.dispose()
+
+      // Then network error is surfaced and no write occurs
+      expect(mockWriteContract).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(result.current.error?.message).toBe('Please switch to Sepolia')
+      })
+    })
+
+    it('sets "No token selected" error and does NOT write for dummy zero-address token', async () => {
+      // Given a dummy token with zero address
+      const dummyToken: CategorizedToken = {
+        ...mockToken,
+        address: '0x0000000000000000000000000000000000000000',
+      }
+      vi.mocked(useSimulateContract).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: false,
+        isFetching: false,
+      } as never)
+
+      const mockWriteContract = vi.fn()
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: mockWriteContract,
+        isPending: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
+
+      const {result} = renderHook(() => useTokenDisposal(dummyToken))
+
+      // When dispose is called
+      await result.current.dispose()
+
+      // Then validation error is set and no write occurs
+      expect(mockWriteContract).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(result.current.error?.message).toBe('No token selected for disposal')
+      })
+    })
+
+    it('sets "has no balance" error and does NOT write for zero-balance token', async () => {
+      // Given a token with zero balance
+      const zeroBalanceToken: CategorizedToken = {
+        ...mockToken,
+        balance: BigInt(0),
+        symbol: 'USDC',
+      }
+      vi.mocked(useSimulateContract).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: false,
+        isFetching: false,
+      } as never)
+
+      const mockWriteContract = vi.fn()
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: mockWriteContract,
+        isPending: false,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
+
+      const {result} = renderHook(() => useTokenDisposal(zeroBalanceToken))
+
+      // When dispose is called
+      await result.current.dispose()
+
+      // Then balance error is set and no write occurs
+      expect(mockWriteContract).not.toHaveBeenCalled()
+      await waitFor(() => {
+        expect(result.current.error?.message).toBe('USDC has no balance to dispose')
+      })
     })
   })
 
-  it('sets error state and shows a toast when disposal fails', async () => {
-    const failure = new Error('User rejected transaction') as Error & {shortMessage?: string}
-    const {result} = renderHook(() => useTokenDisposal(mockToken))
+  describe('onSuccess / onError mutation callbacks', () => {
+    it('adds the disposal transaction to the queue on success', () => {
+      const mockAddTransaction = vi.fn()
+      vi.mocked(useTransactionQueue).mockReturnValue({
+        addTransaction: mockAddTransaction,
+      } as never)
 
-    const mutationConfig = vi.mocked(useWriteContract).mock.calls[0]?.[0]?.mutation
+      renderHook(() => useTokenDisposal(mockToken))
 
-    // Given a submitted disposal transaction
-    // When wagmi reports an error
-    act(() => {
-      mutationConfig?.onError?.(failure as never, {} as never, {}, {} as never)
+      const mutationConfig = vi.mocked(useWriteContract).mock.calls[0]?.[0]?.mutation
+      const hash = '0xabc123' as Address
+
+      // Given a submitted disposal transaction
+      // When wagmi reports a successful submission
+      mutationConfig?.onSuccess?.(hash, {} as never, {}, {} as never)
+
+      // Then the transaction is queued for receipt monitoring
+      expect(mockAddTransaction).toHaveBeenCalledWith({
+        hash,
+        chainId: 11155111,
+        type: 'dispose',
+        title: 'Dispose USDC',
+        description: 'Burn 1000 USDC',
+        value: mockToken.balance,
+        to: BURN_ADDRESS,
+        from: mockUserAddress,
+      })
     })
 
-    // Then the hook exposes the error and notifies the user
-    return waitFor(() => {
-      expect(result.current.error).toBe(failure)
-      expect(toast.error).toHaveBeenCalledWith('Disposal failed: User rejected transaction')
+    it('sets error state and shows a toast when disposal fails', async () => {
+      const failure = new Error('User rejected transaction') as Error & {shortMessage?: string}
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
+
+      const mutationConfig = vi.mocked(useWriteContract).mock.calls[0]?.[0]?.mutation
+
+      // Given a submitted disposal transaction
+      // When wagmi reports an error
+      act(() => {
+        mutationConfig?.onError?.(failure as never, {} as never, {}, {} as never)
+      })
+
+      // Then the hook exposes the error and notifies the user
+      return waitFor(() => {
+        expect(result.current.error).toBe(failure)
+        expect(toast.error).toHaveBeenCalledWith('Disposal failed: User rejected transaction')
+      })
     })
   })
 
-  it('returns pending state while the disposal transaction is in flight', () => {
-    vi.mocked(useWriteContract).mockReturnValue({
-      writeContract: vi.fn(),
-      isPending: true,
-      isSuccess: false,
-      error: null,
-      data: undefined,
-    } as never)
+  describe('derived state', () => {
+    it('returns pending state while the disposal transaction is in flight', () => {
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: vi.fn(),
+        isPending: true,
+        isSuccess: false,
+        error: null,
+        data: undefined,
+      } as never)
 
-    const {result} = renderHook(() => useTokenDisposal(mockToken))
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
 
-    // Given wagmi reports a pending write
-    // When the hook is read
-    // Then isPending stays true for real-time status rendering
-    expect(result.current.isPending).toBe(true)
-  })
+      // Given wagmi reports a pending write
+      // When the hook is read
+      // Then isPending stays true for real-time status rendering
+      expect(result.current.isPending).toBe(true)
+    })
 
-  it('returns the submitted transaction hash for explorer linking', () => {
-    const txHash = '0xfeedbeef' as Address
-    vi.mocked(useWriteContract).mockReturnValue({
-      writeContract: vi.fn(),
-      isPending: false,
-      isSuccess: true,
-      error: null,
-      data: txHash,
-    } as never)
+    it('returns the submitted transaction hash for explorer linking', () => {
+      const txHash = '0xfeedbeef' as Address
+      vi.mocked(useWriteContract).mockReturnValue({
+        writeContract: vi.fn(),
+        isPending: false,
+        isSuccess: true,
+        error: null,
+        data: txHash,
+      } as never)
 
-    const {result} = renderHook(() => useTokenDisposal(mockToken))
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
 
-    // Given wagmi has a submitted disposal hash
-    // When the hook is read
-    // Then the hash is exposed for explorer links while the queue checks receipt status
-    expect(result.current.txHash).toBe(txHash)
+      // Given wagmi has a submitted disposal hash
+      // When the hook is read
+      // Then the hash is exposed for explorer links while the queue checks receipt status
+      expect(result.current.txHash).toBe(txHash)
+    })
+
+    it('exposes canDispose=true only when simulation succeeded and no errors', () => {
+      // Given a successful simulation with no errors
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
+
+      // Then canDispose is true
+      expect(result.current.canDispose).toBe(true)
+      expect(result.current.isSimulating).toBe(false)
+    })
+
+    it('exposes isSimulating=true while simulation is in flight', () => {
+      // Given simulation is in progress
+      vi.mocked(useSimulateContract).mockReturnValue({
+        data: undefined,
+        error: null,
+        isLoading: true,
+        isFetching: true,
+      } as never)
+
+      const {result} = renderHook(() => useTokenDisposal(mockToken))
+
+      // Then isSimulating is true and canDispose is false
+      expect(result.current.isSimulating).toBe(true)
+      expect(result.current.canDispose).toBe(false)
+    })
   })
 })

--- a/hooks/use-token-disposal.ts
+++ b/hooks/use-token-disposal.ts
@@ -1,7 +1,7 @@
-import {useCallback, useState} from 'react'
+import {useCallback, useMemo, useState} from 'react'
 import toast from 'react-hot-toast'
-import {erc20Abi, formatUnits} from 'viem'
-import {useAccount, useChainId, useWriteContract} from 'wagmi'
+import {erc20Abi, formatUnits, isAddress, zeroAddress} from 'viem'
+import {useAccount, useChainId, useSimulateContract, useWriteContract} from 'wagmi'
 import type {CategorizedToken} from '@/lib/web3/token-filtering'
 
 import {useTransactionQueue} from './use-transaction-queue'
@@ -11,8 +11,11 @@ export const BURN_ADDRESS = '0x000000000000000000000000000000000000dEaD' as cons
 
 export interface UseTokenDisposalReturn {
   dispose: () => Promise<void>
-  isPending: boolean
+  isPending: boolean // write-only pending, does NOT include simulation
   isSuccess: boolean
+  isSimulating: boolean
+  canDispose: boolean
+  isSimulationEnabled: boolean
   error: Error | null
   txHash: `0x${string}` | undefined
 }
@@ -22,8 +25,45 @@ export function useTokenDisposal(token: CategorizedToken): UseTokenDisposalRetur
   const {address: userAddress} = useAccount()
   const {getUnsupportedNetworkError, isConnected} = useWallet()
   const {addTransaction} = useTransactionQueue()
-  const [error, setError] = useState<Error | null>(null)
+  const [localError, setLocalError] = useState<Error | null>(null)
   const networkError = getUnsupportedNetworkError()
+
+  const tokenValidationError = useMemo(() => {
+    if (!isAddress(token.address, {strict: false}) || token.address.toLowerCase() === zeroAddress) {
+      return new Error('No token selected for disposal')
+    }
+    if (token.balance <= BigInt(0)) {
+      return new Error(`${token.symbol || 'Token'} has no balance to dispose`)
+    }
+    return null
+  }, [token.address, token.balance, token.symbol])
+
+  const isSimulationEnabled =
+    localError == null &&
+    typeof userAddress === 'string' &&
+    isConnected &&
+    networkError === null &&
+    tokenValidationError === null
+
+  const {
+    data: simulateData,
+    error: simulateError,
+    isLoading: isSimulationLoading,
+    isFetching: isSimulationFetching,
+  } = useSimulateContract({
+    address: token.address,
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [BURN_ADDRESS, token.balance],
+    account: typeof userAddress === 'string' ? userAddress : undefined,
+    chainId,
+    query: {
+      enabled: isSimulationEnabled,
+      retry: false,
+      staleTime: Number.POSITIVE_INFINITY,
+      refetchOnWindowFocus: false,
+    },
+  })
 
   const {
     writeContract,
@@ -46,15 +86,24 @@ export function useTokenDisposal(token: CategorizedToken): UseTokenDisposalRetur
         })
 
         toast.success(`${token.symbol} disposal submitted`)
-        setError(null)
+        setLocalError(null)
       },
       onError: mutationError => {
         console.error('Token disposal failed:', mutationError)
-        setError(mutationError)
+        setLocalError(mutationError)
         toast.error(`Disposal failed: ${mutationError.message}`)
       },
     },
   })
+
+  const simulationRequest = simulateData?.request
+  const effectiveError = localError ?? simulateError ?? writeError ?? null
+  const canDispose = effectiveError == null && isSimulationEnabled && simulationRequest != null
+  const isSimulating =
+    isSimulationEnabled &&
+    simulationRequest == null &&
+    simulateError == null &&
+    (isSimulationLoading || isSimulationFetching)
 
   const dispose = useCallback(async () => {
     if (typeof userAddress !== 'string' || !isConnected || networkError !== null) {
@@ -62,25 +111,31 @@ export function useTokenDisposal(token: CategorizedToken): UseTokenDisposalRetur
         typeof userAddress === 'string'
           ? (networkError?.error.userFriendlyMessage ?? 'Network configuration error - please check your connection')
           : 'Wallet connection required to dispose tokens'
-
-      setError(new Error(errorMessage))
+      setLocalError(new Error(errorMessage))
       return
     }
-
-    writeContract({
-      address: token.address,
-      abi: erc20Abi,
-      functionName: 'transfer',
-      args: [BURN_ADDRESS, token.balance],
-      chainId,
-    })
-  }, [chainId, isConnected, networkError, token.address, token.balance, userAddress, writeContract])
+    if (tokenValidationError !== null) {
+      setLocalError(tokenValidationError)
+      return
+    }
+    if (simulateError !== null) {
+      setLocalError(simulateError)
+      return
+    }
+    if (simulationRequest == null) {
+      return // never write blind
+    }
+    writeContract(simulationRequest)
+  }, [isConnected, networkError, simulateError, simulationRequest, tokenValidationError, userAddress, writeContract])
 
   return {
     dispose,
     isPending,
     isSuccess,
-    error: error ?? writeError,
+    isSimulating,
+    canDispose,
+    isSimulationEnabled,
+    error: effectiveError,
     txHash: data,
   }
 }


### PR DESCRIPTION
## Why

The ERC-20 disposal flow fired `writeContract` blind. A doomed `transfer()` — fee-on-transfer tokens, paused/restricted tokens, or balance edge cases — only surfaced **after** the user signed and spent gas. This is the most safety-sensitive path in the app, so it should fail closed before asking for a signature.

## What

Add a `useSimulateContract` preflight to `useTokenDisposal`:

- Each token's `transfer(burnAddress, balance)` is simulated first, gated by connection / supported-network / valid-token / non-zero-balance checks.
- `writeContract` **only ever receives the simulated `request`** — it never constructs its own args and never fires without a successful simulation.
- A failed simulation surfaces as that token's `error` and is reported as a failed disposal **without prompting a signature**.
- Invariant: no code path both reports an error and fires a write.

`DisposalExecutor` now waits for `canDispose` before triggering, showing a "Checking transfer safety..." state. The hook exposes `isSimulating` / `canDispose` / `isSimulationEnabled` for the UI.

## Tests

TDD — tests written first. `use-token-disposal.test.ts` 5 → 18 tests (simulation config, success→write-with-request, loading→no-write, failure→no-write+error, disconnected/unsupported/dummy-token/zero-balance guards). `disposal-flow.test.tsx` 8 → 12 (simulating/failure/success executor states).

## Verification

- `pnpm test` — 65 files, 1291 passed / 7 skipped
- `pnpm type-check` — clean
- `pnpm lint` — 0 errors

Part of the post-MVP security/privacy hardening pass.