### PR TITLE
chore(env): drop stale multi-chain RPC vars, document Sepolia override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,22 +14,14 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
 
 # =============================================================================
-# Optional RPC Endpoint Overrides
+# Optional RPC Endpoint Override
 # =============================================================================
-# By default, the app uses public RPC endpoints for each network.
-# You can override these with your own RPC URLs for better performance.
+# By default, the app uses a public Sepolia RPC endpoint.
+# Override it with your own RPC URL for better reliability.
 
-# Ethereum Mainnet RPC URL
-# Example: https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-# NEXT_PUBLIC_ETHEREUM_RPC_URL=
-
-# Polygon Mainnet RPC URL
-# Example: https://polygon-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-# NEXT_PUBLIC_POLYGON_RPC_URL=
-
-# Arbitrum One RPC URL
-# Example: https://arb-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-# NEXT_PUBLIC_ARBITRUM_RPC_URL=
+# Sepolia Testnet RPC URL
+# Example: https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
+# NEXT_PUBLIC_SEPOLIA_RPC_URL=
 
 # =============================================================================
 # Optional Feature Flags

--- a/docs/deployment/vercel-setup.md
+++ b/docs/deployment/vercel-setup.md
@@ -52,17 +52,11 @@ NEXT_PUBLIC_APP_URL=https://tokentoilet-staging.vercel.app  # Preview
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=your_project_id_here
 ```
 
-### Optional RPC Overrides
+### Optional RPC Override
 
 ```bash
-# Ethereum Mainnet
-NEXT_PUBLIC_ETHEREUM_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-
-# Polygon Mainnet
-NEXT_PUBLIC_POLYGON_RPC_URL=https://polygon-mainnet.g.alchemy.com/v2/YOUR_API_KEY
-
-# Arbitrum One
-NEXT_PUBLIC_ARBITRUM_RPC_URL=https://arb-mainnet.g.alchemy.com/v2/YOUR_API_KEY
+# Sepolia Testnet
+NEXT_PUBLIC_SEPOLIA_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY
 ```
 
 ### Feature Flags by Environment

--- a/docs/development/environment-setup.md
+++ b/docs/development/environment-setup.md
@@ -76,14 +76,14 @@ SKIP_ENV_VALIDATION=true pnpm build
 
 ### Alchemy Setup
 1. Visit [Alchemy Dashboard](https://dashboard.alchemy.com/)
-2. Create a new app for each network (Ethereum, Polygon, Arbitrum)
-3. Copy the HTTP URLs to your `.env.local`
+2. Create a new app on the Sepolia network
+3. Copy the HTTP URL to your `.env.local` as `NEXT_PUBLIC_SEPOLIA_RPC_URL`
 
 ### Infura Setup
 1. Visit [Infura Dashboard](https://infura.io/dashboard)
 2. Create a new project
-3. Enable Ethereum, Polygon, and Arbitrum networks
-4. Use the provided endpoints
+3. Enable the Sepolia network
+4. Use the provided endpoint
 
 ### Rate Limiting Considerations
 - Public RPCs have rate limits

--- a/docs/development/environment-setup.md
+++ b/docs/development/environment-setup.md
@@ -35,22 +35,14 @@ This guide explains how to configure environment variables for the Token Toilet 
 - **How to get**: Visit [WalletConnect Cloud](https://cloud.walletconnect.com)
 - **Validation**: Must be a valid hexadecimal string
 
-### Optional RPC Endpoint Overrides
+### Optional RPC Endpoint Override
 
-By default, the application uses public RPC endpoints. You can override these for better performance:
+By default, the application uses a public Sepolia RPC endpoint. You can override it for better reliability:
 
-#### `NEXT_PUBLIC_ETHEREUM_RPC_URL`
-- **Default**: Public Ethereum RPC
-- **Example**: `https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY`
+#### `NEXT_PUBLIC_SEPOLIA_RPC_URL`
+- **Default**: Public Sepolia RPC
+- **Example**: `https://eth-sepolia.g.alchemy.com/v2/YOUR_API_KEY`
 - **Providers**: Alchemy, Infura, Ankr, etc.
-
-#### `NEXT_PUBLIC_POLYGON_RPC_URL`
-- **Default**: Public Polygon RPC
-- **Example**: `https://polygon-mainnet.g.alchemy.com/v2/YOUR_API_KEY`
-
-#### `NEXT_PUBLIC_ARBITRUM_RPC_URL`
-- **Default**: Public Arbitrum RPC
-- **Example**: `https://arb-mainnet.g.alchemy.com/v2/YOUR_API_KEY`
 
 ### Optional Feature Flags
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -138,7 +138,7 @@ tokentoilet/
 1. **Always use the custom `useWallet` hook** - Never use wagmi hooks directly in components
 2. **Web3 components require `'use client'` directive** - Client-side only
 3. **Comprehensive error handling** - Never throw on disconnect/connection errors
-4. **Network validation** - Support Ethereum, Polygon, Arbitrum with auto-switching
+4. **Network validation** - Sepolia testnet only for v1.0, with prompt to switch when on an unsupported network
 
 ### Example Component
 
@@ -308,7 +308,7 @@ pnpm start
 
 - Verify `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` is set correctly
 - Check browser wallet extensions are enabled
-- Ensure supported networks (Ethereum, Polygon, Arbitrum)
+- Ensure the wallet is on the supported network (Sepolia testnet)
 
 #### Build Errors
 

--- a/env.ts
+++ b/env.ts
@@ -25,7 +25,6 @@ export const schemas = {
   // @keep-sorted
   client: {
     NEXT_PUBLIC_APP_URL: z.url('Must be a valid URL'),
-    NEXT_PUBLIC_ARBITRUM_RPC_URL: rpcUrlSchema.optional(),
     NEXT_PUBLIC_ENABLE_ANALYTICS: z
       .string()
       .transform(val => val === 'true')
@@ -36,8 +35,6 @@ export const schemas = {
       .transform(val => val === 'true')
       .pipe(z.boolean())
       .default(false),
-    NEXT_PUBLIC_ETHEREUM_RPC_URL: rpcUrlSchema.optional(),
-    NEXT_PUBLIC_POLYGON_RPC_URL: rpcUrlSchema.optional(),
     NEXT_PUBLIC_SEPOLIA_RPC_URL: rpcUrlSchema.optional(),
     NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: walletConnectProjectIdSchema,
   },
@@ -55,10 +52,7 @@ export const env = createEnv({
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
     NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID,
 
-    // Optional RPC endpoint overrides
-    NEXT_PUBLIC_ETHEREUM_RPC_URL: process.env.NEXT_PUBLIC_ETHEREUM_RPC_URL,
-    NEXT_PUBLIC_POLYGON_RPC_URL: process.env.NEXT_PUBLIC_POLYGON_RPC_URL,
-    NEXT_PUBLIC_ARBITRUM_RPC_URL: process.env.NEXT_PUBLIC_ARBITRUM_RPC_URL,
+    // Optional RPC endpoint override
     NEXT_PUBLIC_SEPOLIA_RPC_URL: process.env.NEXT_PUBLIC_SEPOLIA_RPC_URL,
 
     // Feature flags


### PR DESCRIPTION
Removes pre-rebaseline cruft from the env configuration.

## What

`env.ts` still declared `NEXT_PUBLIC_{ETHEREUM,POLYGON,ARBITRUM}_RPC_URL` from the original multi-chain design. None are referenced anywhere — only `NEXT_PUBLIC_SEPOLIA_RPC_URL` is wired into `lib/web3/config.ts`. 

- Remove the three unused vars from the env schema and the runtime env map.
- Replace the three stale entries in `.env.example` with `NEXT_PUBLIC_SEPOLIA_RPC_URL` — the actually-supported override, which was previously undocumented.

## Verification

- `pnpm type-check` — clean
- `pnpm lint` — 0 errors

Config-only; no application logic touched. Part of the post-MVP hardening cleanup.