### PR TITLE
fix: skip unmapped chains in discovery instead of aborting the scan

### DIFF
--- a/components/web3/token-list.test.tsx
+++ b/components/web3/token-list.test.tsx
@@ -310,6 +310,34 @@ describe('TokenList', () => {
       expect(mockRefetch).toHaveBeenCalledTimes(1)
     })
 
+    it('renders discovered tokens (not the fatal error state) when discovery is partial — UNSUPPORTED_CHAIN with tokens present', () => {
+      // A chain in the set was unsupported, but a supported chain returned
+      // tokens. The partial-success result must still render the tokens rather
+      // than the fatal "Could not scan wallet" screen.
+      mockUseTokenDiscovery.mockReturnValue({
+        tokens: [createMockDiscoveredToken()],
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        isSuccess: true,
+        discoveryErrors: [
+          {type: 'UNSUPPORTED_CHAIN', chainId: 1, message: 'Chain 1 is not supported by token discovery'},
+        ],
+        chainsScanned: 2,
+        contractsChecked: 1,
+        refetch: vi.fn(),
+        refresh: vi.fn(),
+      })
+
+      render(<TokenList config={{enableVirtualScrolling: false}} />, {wrapper: createWrapper()})
+
+      // The fatal "Could not scan wallet" screen and its retry button must not
+      // appear — UNSUPPORTED_CHAIN with tokens present is a partial success, not
+      // a fatal discovery failure.
+      expect(screen.queryByText('Could not scan wallet')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', {name: /Try Again/i})).not.toBeInTheDocument()
+    })
+
     it('renders empty-success state with neutral copy distinct from error and unavailable', () => {
       mockUseTokenDiscovery.mockReturnValue({
         tokens: [],

--- a/components/web3/token-list.tsx
+++ b/components/web3/token-list.tsx
@@ -193,7 +193,14 @@ export function TokenList({
 
   const safeDiscoveryErrors = discoveryErrors ?? []
   const hasAuthMissing = safeDiscoveryErrors.some(e => e.type === 'AUTH_MISSING')
-  const hasDiscoveryError = safeDiscoveryErrors.length > 0 && !hasAuthMissing
+  // UNSUPPORTED_CHAIN is a partial-discovery warning, not a fatal failure: one
+  // chain in the set is unsupported but others may have returned tokens. Only a
+  // genuine scan failure (e.g. API_ERROR) should block rendering, and only when
+  // there are no tokens to show — partial results must still render.
+  const fatalDiscoveryErrors = safeDiscoveryErrors.filter(
+    e => e.type !== 'AUTH_MISSING' && e.type !== 'UNSUPPORTED_CHAIN',
+  )
+  const hasDiscoveryError = fatalDiscoveryErrors.length > 0 && discoveredTokens.length === 0
 
   // -------------------------------------------------------------------------
   // Spam filter application (R9b)

--- a/lib/web3/alchemy-endpoints.ts
+++ b/lib/web3/alchemy-endpoints.ts
@@ -26,11 +26,13 @@ export function isAlchemyConfigured(): boolean {
 /**
  * Returns the full Alchemy RPC endpoint URL for the given chain id, or
  * `undefined` when:
- *  - `NEXT_PUBLIC_ALCHEMY_API_KEY` is absent or empty (→ caller emits AUTH_MISSING)
+ *  - `NEXT_PUBLIC_ALCHEMY_API_KEY` is absent or empty
  *  - the chain id is not in the supported Alchemy host map
  *
- * This is the signal `discoverUserTokens` uses to emit an `AUTH_MISSING` error
- * and surface the "discovery unavailable" UX state.
+ * Callers must distinguish these two cases via `isAlchemyConfigured()`: a
+ * missing key is fatal for all chains (AUTH_MISSING), whereas an unmapped chain
+ * affects only that chain (UNSUPPORTED_CHAIN — skip it and scan the rest). Do
+ * not collapse both back into a single AUTH_MISSING path.
  */
 export function getAlchemyEndpoint(chainId: number): string | undefined {
   const key = env.NEXT_PUBLIC_ALCHEMY_API_KEY

--- a/lib/web3/alchemy-endpoints.ts
+++ b/lib/web3/alchemy-endpoints.ts
@@ -13,6 +13,17 @@ const ALCHEMY_HOSTS: Readonly<Record<number, string>> = {
 }
 
 /**
+ * Returns `true` when the Alchemy API key is present and non-empty.
+ *
+ * Use this to distinguish "key absent" (affects all chains) from "chain
+ * unmapped" (affects only that chain) before calling `getAlchemyEndpoint`.
+ */
+export function isAlchemyConfigured(): boolean {
+  const key = env.NEXT_PUBLIC_ALCHEMY_API_KEY
+  return key !== undefined && key !== ''
+}
+
+/**
  * Returns the full Alchemy RPC endpoint URL for the given chain id, or
  * `undefined` when:
  *  - `NEXT_PUBLIC_ALCHEMY_API_KEY` is absent or empty (→ caller emits AUTH_MISSING)

--- a/lib/web3/token-discovery.test.ts
+++ b/lib/web3/token-discovery.test.ts
@@ -15,7 +15,7 @@ import type {Address} from 'viem'
 import {createPublicClient} from 'viem'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {getAlchemyEndpoint} from './alchemy-endpoints'
+import {getAlchemyEndpoint, isAlchemyConfigured} from './alchemy-endpoints'
 import {fetchAlchemyTokenMetadataBatch, fetchWalletTokenBalances} from './alchemy-token-api'
 import {discoverUserTokens, formatTokenBalance, type TokenDiscoveryError} from './token-discovery'
 
@@ -23,7 +23,9 @@ import {discoverUserTokens, formatTokenBalance, type TokenDiscoveryError} from '
 // their position in the file. Placing them after imports is the project
 // convention (see hooks/use-token-discovery.test.tsx).
 vi.mock('./alchemy-endpoints', () => ({
+  [Symbol.toStringTag]: 'Module',
   getAlchemyEndpoint: vi.fn(),
+  isAlchemyConfigured: vi.fn(),
 }))
 
 vi.mock('./alchemy-token-api', () => ({
@@ -44,6 +46,7 @@ vi.mock('viem', async () => {
 // ---------------------------------------------------------------------------
 
 const mockGetAlchemyEndpoint = vi.mocked(getAlchemyEndpoint)
+const mockIsAlchemyConfigured = vi.mocked(isAlchemyConfigured)
 const mockFetchWalletTokenBalances = vi.mocked(fetchWalletTokenBalances)
 const mockFetchAlchemyTokenMetadataBatch = vi.mocked(fetchAlchemyTokenMetadataBatch)
 const mockCreatePublicClient = vi.mocked(createPublicClient)
@@ -82,7 +85,8 @@ function makeMetadataMap(
 
 beforeEach(() => {
   vi.clearAllMocks()
-  // Default: endpoint available.
+  // Default: key is present and endpoint is available.
+  mockIsAlchemyConfigured.mockReturnValue(true)
   mockGetAlchemyEndpoint.mockReturnValue(FAKE_ENDPOINT)
   // Default: createPublicClient returns a stub client.
   // Cast through unknown to avoid the full PublicClient shape requirement.
@@ -252,7 +256,7 @@ describe('edge case — many-token wallet (multi-page)', () => {
 
 describe('error path — AUTH_MISSING', () => {
   it('returns exactly one AUTH_MISSING error and empty tokens when key is absent', async () => {
-    mockGetAlchemyEndpoint.mockReturnValue(undefined)
+    mockIsAlchemyConfigured.mockReturnValue(false)
 
     const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {chainIds: [SEPOLIA_CHAIN_ID]})
 
@@ -267,7 +271,7 @@ describe('error path — AUTH_MISSING', () => {
   })
 
   it('does NOT fall back to any hardcoded token list when key is absent', async () => {
-    mockGetAlchemyEndpoint.mockReturnValue(undefined)
+    mockIsAlchemyConfigured.mockReturnValue(false)
 
     const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {chainIds: [SEPOLIA_CHAIN_ID]})
 
@@ -276,6 +280,74 @@ describe('error path — AUTH_MISSING', () => {
     // The error type must be AUTH_MISSING, not a success with hardcoded tokens.
     const authMissingErrors = result.errors.filter(e => e.type === 'AUTH_MISSING')
     expect(authMissingErrors).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error path: UNSUPPORTED_CHAIN (key present, chain unmapped)
+// ---------------------------------------------------------------------------
+
+const UNMAPPED_CHAIN_ID = 999999
+
+describe('error path — UNSUPPORTED_CHAIN', () => {
+  it('skips unmapped chain and still scans valid chains when key is present', async () => {
+    // isAlchemyConfigured returns true (default), but the unmapped chain has no endpoint.
+    mockGetAlchemyEndpoint.mockImplementation((chainId: number) => {
+      if (chainId === SEPOLIA_CHAIN_ID) return FAKE_ENDPOINT
+      return undefined
+    })
+
+    mockFetchWalletTokenBalances.mockResolvedValue([{contractAddress: TOKEN_A_ADDRESS, balance: BigInt(1_000_000)}])
+    mockFetchAlchemyTokenMetadataBatch.mockResolvedValue(
+      makeMetadataMap([{address: TOKEN_A_ADDRESS, name: 'USD Coin', symbol: 'USDC', decimals: 6}]),
+    )
+
+    const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {
+      chainIds: [UNMAPPED_CHAIN_ID, SEPOLIA_CHAIN_ID],
+    })
+
+    // Valid chain tokens ARE returned.
+    expect(result.tokens).toHaveLength(1)
+    expect(result.tokens[0]?.symbol).toBe('USDC')
+
+    // UNSUPPORTED_CHAIN error for the unmapped chain.
+    const unsupportedErrors = result.errors.filter(e => e.type === 'UNSUPPORTED_CHAIN')
+    expect(unsupportedErrors).toHaveLength(1)
+    expect(unsupportedErrors[0]?.chainId).toBe(UNMAPPED_CHAIN_ID)
+
+    // No AUTH_MISSING error — the key is present.
+    const authErrors = result.errors.filter(e => e.type === 'AUTH_MISSING')
+    expect(authErrors).toHaveLength(0)
+  })
+
+  it('returns empty tokens and one UNSUPPORTED_CHAIN error for a single unmapped chain', async () => {
+    mockGetAlchemyEndpoint.mockReturnValue(undefined)
+
+    const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {
+      chainIds: [UNMAPPED_CHAIN_ID],
+    })
+
+    expect(result.tokens).toHaveLength(0)
+
+    const unsupportedErrors = result.errors.filter(e => e.type === 'UNSUPPORTED_CHAIN')
+    expect(unsupportedErrors).toHaveLength(1)
+    expect(unsupportedErrors[0]?.chainId).toBe(UNMAPPED_CHAIN_ID)
+
+    // Must NOT be AUTH_MISSING — the key is present.
+    const authErrors = result.errors.filter(e => e.type === 'AUTH_MISSING')
+    expect(authErrors).toHaveLength(0)
+
+    // No API calls made for an unsupported chain.
+    expect(mockFetchWalletTokenBalances).not.toHaveBeenCalled()
+  })
+
+  it('UNSUPPORTED_CHAIN is a valid member of the TokenDiscoveryError type union', () => {
+    const error: TokenDiscoveryError = {
+      chainId: SEPOLIA_CHAIN_ID,
+      message: 'Chain 999999 is not supported by token discovery',
+      type: 'UNSUPPORTED_CHAIN',
+    }
+    expect(error.type).toBe('UNSUPPORTED_CHAIN')
   })
 })
 

--- a/lib/web3/token-discovery.ts
+++ b/lib/web3/token-discovery.ts
@@ -27,7 +27,7 @@ import {createPublicClient, erc20Abi, http} from 'viem'
 import {mainnet, sepolia} from 'viem/chains'
 import {readContracts} from 'wagmi/actions'
 
-import {getAlchemyEndpoint} from './alchemy-endpoints'
+import {getAlchemyEndpoint, isAlchemyConfigured} from './alchemy-endpoints'
 import {fetchAlchemyTokenMetadataBatch, fetchWalletTokenBalances} from './alchemy-token-api'
 import {sanitizeTokenDisplay} from './display-sanitization'
 
@@ -131,7 +131,14 @@ export interface TokenDiscoveryError {
   /** Original error object */
   originalError?: Error
   /** Error type for categorization */
-  type: 'RPC_ERROR' | 'CONTRACT_ERROR' | 'VALIDATION_ERROR' | 'UNKNOWN_ERROR' | 'API_ERROR' | 'AUTH_MISSING'
+  type:
+    | 'RPC_ERROR'
+    | 'CONTRACT_ERROR'
+    | 'VALIDATION_ERROR'
+    | 'UNKNOWN_ERROR'
+    | 'API_ERROR'
+    | 'AUTH_MISSING'
+    | 'UNSUPPORTED_CHAIN'
 }
 
 // ---------------------------------------------------------------------------
@@ -181,24 +188,34 @@ export async function discoverUserTokens(
   let contractsChecked = 0
 
   for (const chainId of mergedConfig.chainIds) {
-    // Check for Alchemy endpoint. getAlchemyEndpoint returns undefined when
-    // the key is absent OR the chain is unmapped. We treat both as AUTH_MISSING
-    // at the discovery level — no hardcoded fallback (R10).
-    const endpoint = getAlchemyEndpoint(chainId)
-    if (endpoint === undefined) {
+    // Distinguish "key absent" (all chains affected) from "chain unmapped"
+    // (only this chain affected) so we can skip unmapped chains without
+    // aborting the entire scan.
+    if (!isAlchemyConfigured()) {
       errors.push({
         chainId,
-        message: `Alchemy API key absent or chain ${chainId} not supported — token discovery unavailable`,
+        message: 'Alchemy API key absent — token discovery unavailable',
         type: 'AUTH_MISSING',
       })
-      // Return immediately: if the key is missing it will be missing for all
-      // chains, so there is no point continuing the loop.
+      // Return immediately: the key is missing for all chains.
       return {
         tokens: [],
         errors,
         chainsScanned: mergedConfig.chainIds.length,
         contractsChecked: 0,
       }
+    }
+
+    const endpoint = getAlchemyEndpoint(chainId)
+    if (endpoint === undefined) {
+      // Key is present but this chain is not in ALCHEMY_HOSTS — skip it and
+      // continue scanning the remaining chains.
+      errors.push({
+        chainId,
+        message: `Chain ${chainId} is not supported by token discovery`,
+        type: 'UNSUPPORTED_CHAIN',
+      })
+      continue
     }
 
     const chainResult = await discoverChainTokens(userAddress, chainId, endpoint, mergedConfig)


### PR DESCRIPTION
## What this fixes

Token discovery couldn't tell two different failures apart: a missing Alchemy key (which affects every chain) versus a chain that isn't in the supported host map (which affects only that one chain). Both returned early with `AUTH_MISSING`, so a single unsupported chain would abort the entire scan — including the chains that *are* supported.

Now:
- **No key** → `AUTH_MISSING`, early return (correct — the key is missing for every chain).
- **Key present, chain unmapped** → a per-chain `UNSUPPORTED_CHAIN` error and `continue`, so the remaining chains still get scanned.

`isAlchemyConfigured()` gates the key case; `UNSUPPORTED_CHAIN` is an additive error-type member (no existing members changed).

## Why now

It's latent on the Sepolia-only setup (one supported chain), but it's the correct foundation for the moment a second chain is added — an unsupported chain in the list shouldn't take down discovery for the supported ones.

## Notes

- Surfaced by review feedback on the wallet-enumeration PR (#1179).
- Adds three `discoverUserTokens` tests: no-key path, a mixed valid+unmapped chain set (valid chain still returns tokens, unmapped chain reports `UNSUPPORTED_CHAIN`), and a single-unmapped-chain case.
- Full unit suite, type-check, and lint pass.
