### PR TITLE
test: cover the logo render security guards

### DIFF
--- a/components/web3/token-detail.test.tsx
+++ b/components/web3/token-detail.test.tsx
@@ -264,6 +264,82 @@ describe('TokenDetail', () => {
     })
   })
 
+  describe('Logo Render Guards (security)', () => {
+    it('renders the remote logo when all guards pass', () => {
+      // Default mockToken: isVerified=true, spamScore=5, category=VALUABLE
+      // Default mockMetadataReturn: logoURI='https://example.com/logo.png' (safe https)
+      render(<TokenDetail {...mockProps} />)
+
+      const logoEl = screen.getByRole('img', {name: 'Test Token logo'})
+      expect(logoEl).toBeInTheDocument()
+      expect(logoEl).toHaveStyle({backgroundImage: 'url(https://example.com/logo.png)'})
+    })
+
+    it('falls back to icon when logoURI is undefined', () => {
+      mockUseTokenMetadata.mockReturnValue({
+        ...mockMetadataReturn,
+        metadata: {...mockMetadataReturn.metadata, logoURI: undefined},
+      })
+
+      render(<TokenDetail {...mockProps} />)
+
+      expect(screen.queryByRole('img', {name: 'Test Token logo'})).not.toBeInTheDocument()
+    })
+
+    it('falls back to icon when logoURI is empty/whitespace', () => {
+      mockUseTokenMetadata.mockReturnValue({
+        ...mockMetadataReturn,
+        metadata: {...mockMetadataReturn.metadata, logoURI: '   '},
+      })
+
+      render(<TokenDetail {...mockProps} />)
+
+      expect(screen.queryByRole('img', {name: 'Test Token logo'})).not.toBeInTheDocument()
+    })
+
+    it('falls back to icon when logoURI is not https (javascript: scheme)', () => {
+      const maliciousUrl = 'javascript:alert(1)'
+      mockUseTokenMetadata.mockReturnValue({
+        ...mockMetadataReturn,
+        metadata: {...mockMetadataReturn.metadata, logoURI: maliciousUrl},
+      })
+
+      const {container} = render(<TokenDetail {...mockProps} />)
+
+      expect(screen.queryByRole('img', {name: 'Test Token logo'})).not.toBeInTheDocument()
+      // The attacker URL must not appear anywhere in the rendered output's style
+      expect(container.innerHTML).not.toContain(maliciousUrl)
+    })
+
+    it('falls back to icon when logoURI has CSS-url() breakout chars', () => {
+      const maliciousUrl = 'https://evil.example.com/a.png")burglary;('
+      mockUseTokenMetadata.mockReturnValue({
+        ...mockMetadataReturn,
+        metadata: {...mockMetadataReturn.metadata, logoURI: maliciousUrl},
+      })
+
+      const {container} = render(<TokenDetail {...mockProps} />)
+
+      expect(screen.queryByRole('img', {name: 'Test Token logo'})).not.toBeInTheDocument()
+      // The attacker URL must not appear anywhere in the rendered output's style
+      expect(container.innerHTML).not.toContain(maliciousUrl)
+    })
+
+    it('falls back to icon when token is not verified', () => {
+      render(<TokenDetail {...mockProps} token={{...mockToken, isVerified: false}} />)
+
+      expect(screen.queryByRole('img', {name: 'Test Token logo'})).not.toBeInTheDocument()
+    })
+
+    it('falls back to icon when token is suspected spam', () => {
+      // isSuspectedSpam returns true when category === SPAM or spamScore > 70
+      // Using category SPAM to trigger the guard
+      render(<TokenDetail {...mockProps} token={{...mockToken, category: TokenCategory.SPAM}} />)
+
+      expect(screen.queryByRole('img', {name: 'Test Token logo'})).not.toBeInTheDocument()
+    })
+  })
+
   describe('Modal Behavior', () => {
     it('renders as modal when isModal is true', () => {
       render(<TokenDetail {...mockProps} isModal={true} open={true} onClose={vi.fn()} />)


### PR DESCRIPTION
## What this adds

Direct tests for the logo render security guard in `token-detail.tsx` — the one place the app loads a remote, attacker-controlled token logo into a CSS `backgroundImage`. The guard only renders the logo when all five conditions hold (logoURI present and non-empty, `isSafeLogoUrl` passes, token verified, not suspected spam); otherwise it falls back to an icon. None of that was covered.

Seven tests: the happy path plus one per guard condition. The injection cases (`javascript:` scheme, CSS-`url()` breakout characters) assert the attacker URL never appears anywhere in the rendered output — the strongest check, not just "the logo div is absent."

## Notes

- Test-only change; no production code touched.
- Closes the top testing gap from the wallet-enumeration review.
- Confirmed the spam threshold the guard relies on is `category === SPAM || spamScore > 70` (strictly greater).
