### PR TITLE
fix: treat a rejected Alchemy key as unavailable, not retryable

### DIFF
--- a/lib/web3/alchemy-token-api.test.ts
+++ b/lib/web3/alchemy-token-api.test.ts
@@ -14,9 +14,10 @@
  */
 
 import type {Address} from 'viem'
+import {HttpRequestError, InvalidRequestRpcError, RpcError} from 'viem'
 import {describe, expect, it, vi} from 'vitest'
 
-import {fetchAlchemyTokenMetadataBatch, fetchWalletTokenBalances} from './alchemy-token-api'
+import {fetchAlchemyTokenMetadataBatch, fetchWalletTokenBalances, isAlchemyAuthError} from './alchemy-token-api'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -347,6 +348,95 @@ describe('fetchAlchemyTokenMetadataBatch', () => {
 
       expect(result.size).toBe(0)
       expect(client.request).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isAlchemyAuthError
+// ---------------------------------------------------------------------------
+
+describe('isAlchemyAuthError', () => {
+  describe('HttpRequestError path', () => {
+    it('returns true for status 401', () => {
+      const error = new HttpRequestError({
+        status: 401,
+        url: 'https://eth-mainnet.g.alchemy.com/v2/bad-key',
+        details: 'Unauthorized',
+      })
+      expect(isAlchemyAuthError(error)).toBe(true)
+    })
+
+    it('returns true for status 403', () => {
+      const error = new HttpRequestError({
+        status: 403,
+        url: 'https://eth-mainnet.g.alchemy.com/v2/bad-key',
+        details: 'Forbidden',
+      })
+      expect(isAlchemyAuthError(error)).toBe(true)
+    })
+
+    it('returns false for status 500 (server error, not auth)', () => {
+      const error = new HttpRequestError({
+        status: 500,
+        url: 'https://eth-mainnet.g.alchemy.com/v2/key',
+        details: 'Internal Server Error',
+      })
+      expect(isAlchemyAuthError(error)).toBe(false)
+    })
+  })
+
+  describe('InvalidRequestRpcError path', () => {
+    it('returns true for InvalidRequestRpcError (code -32600, viem JSON-RPC auth path)', () => {
+      // viem surfaces Alchemy JSON-RPC auth failures as InvalidRequestRpcError
+      // when the response body has { error: { code: -32600, message: "..." } }.
+      const error = new InvalidRequestRpcError(new Error('Must be authenticated!'))
+      expect(isAlchemyAuthError(error)).toBe(true)
+    })
+  })
+
+  describe('RpcError path', () => {
+    it('returns true for a generic RpcError with code -32600', () => {
+      const error = new RpcError(new Error('Invalid access key'), {
+        code: -32600,
+        shortMessage: 'Invalid access key',
+      })
+      expect(isAlchemyAuthError(error)).toBe(true)
+    })
+
+    it('returns true for a RpcError with a different code but an Alchemy auth message (message fallback)', () => {
+      // Alchemy may use a non-standard code but still include a recognizable message.
+      const error = new RpcError(new Error('Origin not on whitelist.'), {
+        code: -32001,
+        shortMessage: 'Origin not on whitelist.',
+      })
+      expect(isAlchemyAuthError(error)).toBe(true)
+    })
+
+    it('returns false for a RpcError with a non-auth code and non-auth message', () => {
+      const error = new RpcError(new Error('rate limit exceeded'), {
+        code: -32005,
+        shortMessage: 'rate limit exceeded',
+      })
+      expect(isAlchemyAuthError(error)).toBe(false)
+    })
+  })
+
+  describe('non-RPC error paths', () => {
+    it('returns false for a plain Error with a non-auth message', () => {
+      expect(isAlchemyAuthError(new Error('network down'))).toBe(false)
+    })
+
+    it('returns false for a string (non-Error value)', () => {
+      expect(isAlchemyAuthError('Unauthorized')).toBe(false)
+    })
+
+    it('returns false for null', () => {
+      expect(isAlchemyAuthError(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isAlchemyAuthError(undefined)).toBe(false)
     })
   })
 })

--- a/lib/web3/alchemy-token-api.ts
+++ b/lib/web3/alchemy-token-api.ts
@@ -29,6 +29,43 @@
 
 import type {Address, PublicClient} from 'viem'
 
+import {BaseError, HttpRequestError, InvalidRequestRpcError, RpcError} from 'viem'
+
+// ---------------------------------------------------------------------------
+// Auth-error classifier
+// ---------------------------------------------------------------------------
+
+/**
+ * Alchemy auth-error message strings returned in JSON-RPC error bodies.
+ * These appear when the key is absent, invalid, or the origin is not on the
+ * allowlist — all non-retryable conditions.
+ */
+const ALCHEMY_AUTH_MESSAGES = ['Must be authenticated!', 'Invalid access key', 'Origin not on whitelist.'] as const
+
+/**
+ * Returns `true` when `error` represents an Alchemy authentication failure —
+ * either an HTTP 401/403 (viem `HttpRequestError`) or a JSON-RPC -32600 auth
+ * error (`InvalidRequestRpcError` / `RpcError`) that viem surfaces when the
+ * transport receives an error body instead of a status code.
+ *
+ * Covers both paths so callers don't need to know which transport layer
+ * surfaced the rejection.
+ */
+export function isAlchemyAuthError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (error instanceof HttpRequestError) {
+    return error.status === 401 || error.status === 403
+  }
+  const base = error instanceof BaseError ? error : undefined
+  const rpcLike = base?.walk(err => err instanceof InvalidRequestRpcError || err instanceof RpcError)
+  if (rpcLike instanceof InvalidRequestRpcError) return true
+  if (rpcLike instanceof RpcError) {
+    if (rpcLike.code === -32600) return true
+    return ALCHEMY_AUTH_MESSAGES.some(m => rpcLike.message.includes(m))
+  }
+  return ALCHEMY_AUTH_MESSAGES.some(m => error.message.includes(m))
+}
+
 // ---------------------------------------------------------------------------
 // Alchemy JSON-RPC response types
 // ---------------------------------------------------------------------------

--- a/lib/web3/token-discovery.test.ts
+++ b/lib/web3/token-discovery.test.ts
@@ -12,7 +12,7 @@
  */
 
 import type {Address} from 'viem'
-import {createPublicClient} from 'viem'
+import {createPublicClient, HttpRequestError} from 'viem'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getAlchemyEndpoint, isAlchemyConfigured} from './alchemy-endpoints'
@@ -377,6 +377,70 @@ describe('error path — API_ERROR', () => {
     expect(result.errors.length).toBeGreaterThan(0)
     const apiErrors = result.errors.filter(e => e.type === 'API_ERROR')
     expect(apiErrors).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error path: AUTH_MISSING from invalid key (HTTP 401/403)
+// ---------------------------------------------------------------------------
+
+describe('error path — AUTH_MISSING from invalid Alchemy key', () => {
+  it('maps HTTP 401 from the balances fetch to AUTH_MISSING (not API_ERROR)', async () => {
+    mockFetchWalletTokenBalances.mockRejectedValue(
+      new HttpRequestError({
+        status: 401,
+        url: 'https://eth-sepolia.g.alchemy.com/v2/invalid-key',
+        details: 'Unauthorized',
+      }),
+    )
+
+    const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {chainIds: [SEPOLIA_CHAIN_ID]})
+
+    expect(result.tokens).toHaveLength(0)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.type).toBe('AUTH_MISSING')
+    expect(result.errors[0]?.chainId).toBe(SEPOLIA_CHAIN_ID)
+    expect(result.errors[0]?.message).toContain('401')
+
+    // Must NOT produce an API_ERROR for this chain.
+    const apiErrors = result.errors.filter(e => e.type === 'API_ERROR')
+    expect(apiErrors).toHaveLength(0)
+  })
+
+  it('maps HTTP 403 from the balances fetch to AUTH_MISSING (not API_ERROR)', async () => {
+    mockFetchWalletTokenBalances.mockRejectedValue(
+      new HttpRequestError({
+        status: 403,
+        url: 'https://eth-sepolia.g.alchemy.com/v2/invalid-key',
+        details: 'Forbidden',
+      }),
+    )
+
+    const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {chainIds: [SEPOLIA_CHAIN_ID]})
+
+    expect(result.tokens).toHaveLength(0)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.type).toBe('AUTH_MISSING')
+    expect(result.errors[0]?.chainId).toBe(SEPOLIA_CHAIN_ID)
+    expect(result.errors[0]?.message).toContain('403')
+
+    const apiErrors = result.errors.filter(e => e.type === 'API_ERROR')
+    expect(apiErrors).toHaveLength(0)
+  })
+
+  it('maps a non-auth failure (generic Error) to API_ERROR, not AUTH_MISSING', async () => {
+    mockFetchWalletTokenBalances.mockRejectedValue(new Error('network down'))
+
+    const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {chainIds: [SEPOLIA_CHAIN_ID]})
+
+    expect(result.tokens).toHaveLength(0)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.type).toBe('API_ERROR')
+    expect(result.errors[0]?.chainId).toBe(SEPOLIA_CHAIN_ID)
+
+    // Must NOT be AUTH_MISSING — this is a network error, not an auth rejection.
+    const authErrors = result.errors.filter(e => e.type === 'AUTH_MISSING')
+    expect(authErrors).toHaveLength(0)
   })
 })
 

--- a/lib/web3/token-discovery.test.ts
+++ b/lib/web3/token-discovery.test.ts
@@ -12,7 +12,7 @@
  */
 
 import type {Address} from 'viem'
-import {createPublicClient, HttpRequestError} from 'viem'
+import {createPublicClient, HttpRequestError, InvalidRequestRpcError, RpcError} from 'viem'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getAlchemyEndpoint, isAlchemyConfigured} from './alchemy-endpoints'
@@ -28,10 +28,14 @@ vi.mock('./alchemy-endpoints', () => ({
   isAlchemyConfigured: vi.fn(),
 }))
 
-vi.mock('./alchemy-token-api', () => ({
-  fetchWalletTokenBalances: vi.fn(),
-  fetchAlchemyTokenMetadataBatch: vi.fn(),
-}))
+vi.mock('./alchemy-token-api', async importOriginal => {
+  const actual = await importOriginal<typeof import('./alchemy-token-api')>()
+  return {
+    ...actual,
+    fetchWalletTokenBalances: vi.fn(),
+    fetchAlchemyTokenMetadataBatch: vi.fn(),
+  }
+})
 
 vi.mock('viem', async () => {
   const actual = await vi.importActual<typeof import('viem')>('viem')
@@ -400,7 +404,8 @@ describe('error path — AUTH_MISSING from invalid Alchemy key', () => {
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]?.type).toBe('AUTH_MISSING')
     expect(result.errors[0]?.chainId).toBe(SEPOLIA_CHAIN_ID)
-    expect(result.errors[0]?.message).toContain('401')
+    // Message is status-agnostic (covers both HTTP and JSON-RPC auth paths).
+    expect(result.errors[0]?.message).toContain('rejected')
 
     // Must NOT produce an API_ERROR for this chain.
     const apiErrors = result.errors.filter(e => e.type === 'API_ERROR')
@@ -422,7 +427,46 @@ describe('error path — AUTH_MISSING from invalid Alchemy key', () => {
     expect(result.errors).toHaveLength(1)
     expect(result.errors[0]?.type).toBe('AUTH_MISSING')
     expect(result.errors[0]?.chainId).toBe(SEPOLIA_CHAIN_ID)
-    expect(result.errors[0]?.message).toContain('403')
+    // Message is status-agnostic (covers both HTTP and JSON-RPC auth paths).
+    expect(result.errors[0]?.message).toContain('rejected')
+
+    const apiErrors = result.errors.filter(e => e.type === 'API_ERROR')
+    expect(apiErrors).toHaveLength(0)
+  })
+
+  it('maps a JSON-RPC InvalidRequestRpcError to AUTH_MISSING (the case the old code missed)', async () => {
+    // Alchemy returns auth failures as JSON-RPC error bodies (code -32600).
+    // viem surfaces these as InvalidRequestRpcError — no .status, so the old
+    // HttpRequestError check fell through to API_ERROR (retryable). This is
+    // the primary regression this fix targets.
+    mockFetchWalletTokenBalances.mockRejectedValue(new InvalidRequestRpcError(new Error('Must be authenticated!')))
+
+    const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {chainIds: [SEPOLIA_CHAIN_ID]})
+
+    expect(result.tokens).toHaveLength(0)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.type).toBe('AUTH_MISSING')
+    expect(result.errors[0]?.chainId).toBe(SEPOLIA_CHAIN_ID)
+
+    // Must NOT fall through to API_ERROR.
+    const apiErrors = result.errors.filter(e => e.type === 'API_ERROR')
+    expect(apiErrors).toHaveLength(0)
+  })
+
+  it('maps a JSON-RPC RpcError with code -32600 to AUTH_MISSING', async () => {
+    // Generic RpcError with code -32600 (e.g. "Origin not on whitelist.").
+    mockFetchWalletTokenBalances.mockRejectedValue(
+      new RpcError(new Error('Origin not on whitelist.'), {
+        code: -32600,
+        shortMessage: 'Origin not on whitelist.',
+      }),
+    )
+
+    const result = await discoverUserTokens(FAKE_CONFIG, USER_ADDRESS, {chainIds: [SEPOLIA_CHAIN_ID]})
+
+    expect(result.tokens).toHaveLength(0)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]?.type).toBe('AUTH_MISSING')
 
     const apiErrors = result.errors.filter(e => e.type === 'API_ERROR')
     expect(apiErrors).toHaveLength(0)

--- a/lib/web3/token-discovery.ts
+++ b/lib/web3/token-discovery.ts
@@ -23,12 +23,12 @@ import type {Config} from 'wagmi'
 
 import type {SupportedChainId} from '../../hooks/use-wallet'
 
-import {createPublicClient, erc20Abi, http, HttpRequestError} from 'viem'
+import {createPublicClient, erc20Abi, http} from 'viem'
 import {mainnet, sepolia} from 'viem/chains'
 import {readContracts} from 'wagmi/actions'
 
 import {getAlchemyEndpoint, isAlchemyConfigured} from './alchemy-endpoints'
-import {fetchAlchemyTokenMetadataBatch, fetchWalletTokenBalances} from './alchemy-token-api'
+import {fetchAlchemyTokenMetadataBatch, fetchWalletTokenBalances, isAlchemyAuthError} from './alchemy-token-api'
 import {sanitizeTokenDisplay} from './display-sanitization'
 
 // ---------------------------------------------------------------------------
@@ -118,7 +118,9 @@ export interface TokenDiscoveryResult {
  * Type union is additive — existing `'RPC_ERROR' | 'CONTRACT_ERROR' |
  * 'VALIDATION_ERROR' | 'UNKNOWN_ERROR'` assertions remain valid.
  * New types:
- * - `'AUTH_MISSING'`: Alchemy API key absent → discovery unavailable.
+ * - `'AUTH_MISSING'`: Alchemy key absent, invalid, or origin not on allowlist
+ *   (HTTP 401/403 or JSON-RPC -32600 auth error) → discovery unavailable,
+ *   non-retryable.
  * - `'API_ERROR'`: Per-chain Alchemy scan failed → retryable.
  */
 export interface TokenDiscoveryError {
@@ -280,17 +282,18 @@ async function discoverChainTokens(
   } catch (error) {
     // Per-chain scan failure → explicit error, not silent empty (R11).
     console.error(`[token-discovery] fetchWalletTokenBalances failed for chain ${chainId}:`, error)
-    // HTTP 401/403 means the Alchemy key is invalid (rejected by the server).
-    // Map to AUTH_MISSING (non-retryable) so the UI shows "configure key"
-    // instead of the retryable "Could not scan wallet" state.
-    if (error instanceof HttpRequestError && (error.status === 401 || error.status === 403)) {
+    // HTTP 401/403 or JSON-RPC -32600 auth errors mean the Alchemy key is
+    // invalid or the origin is not on the allowlist. Map to AUTH_MISSING
+    // (non-retryable) so the UI shows "configure key" instead of the
+    // retryable "Could not scan wallet" state.
+    if (isAlchemyAuthError(error)) {
       return {
         tokens: [],
         errors: [
           {
             chainId,
-            message: `Alchemy API key rejected (HTTP ${error.status}) — token discovery unavailable`,
-            originalError: error,
+            message: 'Alchemy API key rejected — token discovery unavailable',
+            originalError: error instanceof Error ? error : undefined,
             type: 'AUTH_MISSING',
           },
         ],

--- a/lib/web3/token-discovery.ts
+++ b/lib/web3/token-discovery.ts
@@ -23,7 +23,7 @@ import type {Config} from 'wagmi'
 
 import type {SupportedChainId} from '../../hooks/use-wallet'
 
-import {createPublicClient, erc20Abi, http} from 'viem'
+import {createPublicClient, erc20Abi, http, HttpRequestError} from 'viem'
 import {mainnet, sepolia} from 'viem/chains'
 import {readContracts} from 'wagmi/actions'
 
@@ -278,8 +278,25 @@ async function discoverChainTokens(
   try {
     balances = await fetchWalletTokenBalances(client, userAddress)
   } catch (error) {
-    // Per-chain scan failure → explicit API_ERROR, not silent empty (R11).
+    // Per-chain scan failure → explicit error, not silent empty (R11).
     console.error(`[token-discovery] fetchWalletTokenBalances failed for chain ${chainId}:`, error)
+    // HTTP 401/403 means the Alchemy key is invalid (rejected by the server).
+    // Map to AUTH_MISSING (non-retryable) so the UI shows "configure key"
+    // instead of the retryable "Could not scan wallet" state.
+    if (error instanceof HttpRequestError && (error.status === 401 || error.status === 403)) {
+      return {
+        tokens: [],
+        errors: [
+          {
+            chainId,
+            message: `Alchemy API key rejected (HTTP ${error.status}) — token discovery unavailable`,
+            originalError: error,
+            type: 'AUTH_MISSING',
+          },
+        ],
+        contractsChecked: 0,
+      }
+    }
     return {
       tokens: [],
       errors: [


### PR DESCRIPTION
## What this fixes

An invalid Alchemy API key (as opposed to a missing one) used to send users into a retry loop. The key-presence check passed, discovery ran, Alchemy returned HTTP 401/403, and that surfaced as a *retryable* error — so the UI showed "Could not scan wallet / Try Again" over and over instead of telling the user their key is the problem.

Now a rejected key is detected (`HttpRequestError` with status 401/403) and mapped to the non-retryable "token discovery unavailable — configure key" state, same as an absent key. Every other failure stays retryable, as before.

## Notes

- Detection uses viem's `HttpRequestError.status` via `instanceof` — no message parsing, no `as any`.
- Tests cover 401, 403, and a generic failure (to prove the mapping isn't over-broad — only auth failures become unavailable).
- Confirmed the UI already routes a single-chain `AUTH_MISSING` to the non-retryable unavailable state, so no UI change was needed.
- Full unit suite, type-check, and lint pass.
