### PR TITLE
fix: surface structured discovery error messages in the UI

### DIFF
--- a/components/web3/token-list.test.tsx
+++ b/components/web3/token-list.test.tsx
@@ -287,6 +287,29 @@ describe('TokenList', () => {
       expect(screen.getByRole('button', {name: /Try Again/i})).toBeInTheDocument()
     })
 
+    it('surfaces the structured discoveryErrors message instead of the generic fallback', () => {
+      // discoverUserTokens never throws, so the generic query.error is null and
+      // only the structured discoveryErrors array carries the real reason. The
+      // error UI must show that message, not the generic fallback copy.
+      mockUseTokenDiscovery.mockReturnValue({
+        tokens: [],
+        isLoading: false,
+        error: null,
+        isFetching: false,
+        isSuccess: false,
+        discoveryErrors: [{type: 'API_ERROR', chainId: 11155111, message: 'Could not scan wallet on chain 11155111'}],
+        chainsScanned: 1,
+        contractsChecked: 0,
+        refetch: vi.fn(),
+        refresh: vi.fn(),
+      })
+
+      render(<TokenList config={{enableVirtualScrolling: false}} />, {wrapper: createWrapper()})
+
+      expect(screen.getByText('Could not scan wallet on chain 11155111')).toBeInTheDocument()
+      expect(screen.queryByText('An error occurred while scanning your wallet.')).not.toBeInTheDocument()
+    })
+
     it('retry button calls refetch on API_ERROR', async () => {
       const user = userEvent.setup()
       const mockRefetch = vi.fn()

--- a/components/web3/token-list.tsx
+++ b/components/web3/token-list.tsx
@@ -201,6 +201,11 @@ export function TokenList({
     e => e.type !== 'AUTH_MISSING' && e.type !== 'UNSUPPORTED_CHAIN',
   )
   const hasDiscoveryError = fatalDiscoveryErrors.length > 0 && discoveredTokens.length === 0
+  // discoverUserTokens never throws — failures land in the structured
+  // discoveryErrors array, so query.error (discoveryError) is null on those
+  // paths. Surface the first fatal structured message instead of swallowing it
+  // behind the generic fallback copy.
+  const fatalDiscoveryMessage = fatalDiscoveryErrors[0]?.message
 
   // -------------------------------------------------------------------------
   // Spam filter application (R9b)
@@ -358,7 +363,10 @@ export function TokenList({
           <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
           <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">Could not scan wallet</h3>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            {discoveryError?.message ?? filteringError?.message ?? 'An error occurred while scanning your wallet.'}
+            {discoveryError?.message ??
+              fatalDiscoveryMessage ??
+              filteringError?.message ??
+              'An error occurred while scanning your wallet.'}
           </p>
           <Button onClick={refetchTokens} variant="outline">
             <RefreshCw className="h-4 w-4 mr-2" />


### PR DESCRIPTION
When wallet discovery failed, the error screen always showed the generic fallback instead of the real reason. `discoverUserTokens` doesn't throw — it returns structured errors in a `discoveryErrors` array, so the generic `query.error` the UI read was always null on those paths. The actual message (e.g. "Could not scan wallet on chain 11155111", or a rejected-key message) was sitting in the array, unused.

Now the error UI falls back to the first fatal structured message before the generic copy, so users see what actually went wrong.

- Small UI fix in `token-list.tsx`; the structured errors were already produced correctly, just not surfaced.
- Adds a test asserting the structured message renders and the generic fallback does not.
- Clears the last residual from the wallet-enumeration review.